### PR TITLE
Correctly format ab tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 name := "acquisition-event-producer"
 
-version := "1.0.0"
+version := "1.0.1"
 
 scalaVersion := "2.11.11"
 

--- a/src/main/scala/instances/abTestInfo.scala
+++ b/src/main/scala/instances/abTestInfo.scala
@@ -8,6 +8,6 @@ trait AbTestInfoInstances {
 
   implicit val abTestInfoEncoder: Encoder[AbTestInfo] = Encoder.instance { testInfo =>
     import io.circe.syntax._
-    testInfo.tests.map(t => t.name -> Map("variantName" -> t.variant)).toMap.asJson
+    testInfo.tests.map(test => Map("name" -> test.name, "variant" -> test.variant)).asJson
   }
 }


### PR DESCRIPTION
We believe that acquisition events are not reaching the Avro logger currently, as the acquisition event producer is incorrectly formatting AB tests. This pull request looks to fix this.