### PR TITLE
make endpoint of Ophan service publicaly available

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 name := "acquisition-event-producer"
 
-version := "1.0.1"
+version := "1.0.2"
 
 scalaVersion := "2.11.11"
 

--- a/src/main/scala/com/gu/acquisition/services/OphanService.scala
+++ b/src/main/scala/com/gu/acquisition/services/OphanService.scala
@@ -24,7 +24,7 @@ object OphanServiceError {
   }
 }
 
-class OphanService(endpoint: Uri)(implicit system: ActorSystem, materializer: Materializer) {
+class OphanService(val endpoint: Uri)(implicit system: ActorSystem, materializer: Materializer) {
 
   private val additionalEndpoint = endpoint.copy(path = Uri.Path("/a.gif"))
 


### PR DESCRIPTION
Useful (for e.g. logging) when the Ophan service is being used by other applications.