### PR TITLE
v1.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 name := "acquisition-event-producer"
 
-version := "1.0.1"
+version := "1.0.2"
 
 scalaVersion := "2.11.11"
 

--- a/src/main/scala/com/gu/acquisition/instances/acquisition.scala
+++ b/src/main/scala/com/gu/acquisition/instances/acquisition.scala
@@ -15,7 +15,7 @@ trait AcquisitionInstances {
       "paymentFrequency" -> paymentFrequency.name.asJson,
       "currency" -> currency.asJson,
       "amount" -> amount.asJson,
-      "amountInGBP" -> amount.asJson,
+      "amountInGBP" -> amountInGBP.asJson,
       "paymentProvider" -> paymentProvider.map(_.name).asJson,
       "campaignCode" -> campaignCode.asJson,
       "abTests" -> abTests.asJson,

--- a/src/main/scala/com/gu/acquisition/services/OphanService.scala
+++ b/src/main/scala/com/gu/acquisition/services/OphanService.scala
@@ -24,7 +24,7 @@ object OphanServiceError {
   }
 }
 
-class OphanService(endpoint: Uri)(implicit system: ActorSystem, materializer: Materializer) {
+class OphanService(val endpoint: Uri)(implicit system: ActorSystem, materializer: Materializer) {
 
   private val additionalEndpoint = endpoint.copy(path = Uri.Path("/a.gif"))
 


### PR DESCRIPTION
Changes:

- make Ophan endpoint publicly available - useful (for e.g. logging) when the Ophan service is being used by other applications
- use correct value for `amountInGBP` field when encoding data for submission