### PR TITLE
Generic Ophan service used

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 name := "acquisition-event-producer"
 
-version := "2.0.0-rc.2"
+version := "2.0.0-SNAPSHOT"
 
 scalaVersion := "2.11.11"
 

--- a/src/main/scala/com/gu/acquisition/model/AcquisitionSubmission.scala
+++ b/src/main/scala/com/gu/acquisition/model/AcquisitionSubmission.scala
@@ -1,23 +1,7 @@
 package com.gu.acquisition.model
 
-import com.gu.acquisition.services.{AcquisitionSubmissionProcessor, BuildError, OphanServiceError, ProcessError}
-import com.gu.acquisition.services.OphanServiceError.SubmissionBuildError
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
 import ophan.thrift.event.Acquisition
-import play.api.libs.json.{Reads, Writes, Json => PlayJson}
-import simulacrum.typeclass
-
-case class OphanIds(pageviewId: String, visitId: Option[String], browserId: Option[String])
-
-object OphanIds {
-  import io.circe._
-  import io.circe.generic.semiauto._
-
-  implicit val reads: Reads[OphanIds] = PlayJson.reads[OphanIds]
-  implicit val writes: Writes[OphanIds] = PlayJson.writes[OphanIds]
-
-  implicit val encoder: Encoder[OphanIds] = deriveEncoder[OphanIds]
-  implicit val decoder: Decoder[OphanIds] = deriveDecoder[OphanIds]
-}
 
 /**
   * Encapsulates all the data required to submit an acquisition to Ophan.
@@ -26,32 +10,13 @@ case class AcquisitionSubmission(ophanIds: OphanIds, acquisition: Acquisition)
 
 object AcquisitionSubmission {
 
-  implicit val defaultAcquisitionSubmissionBuilder: AcquisitionSubmissionBuilder[AcquisitionSubmission] =
+  // Type class allows an acquisition submission to passed directly to the submit() method
+  // of an Ophan service instance.
+  implicit val acquisitionSubmissionBuilder: AcquisitionSubmissionBuilder[AcquisitionSubmission] =
     new AcquisitionSubmissionBuilder[AcquisitionSubmission] {
-      import cats.syntax.either._
 
-      override def buildOphanIds(a: AcquisitionSubmission): Either[String, OphanIds] =
-        Either.right(a.ophanIds)
+      override def buildOphanIds(a: AcquisitionSubmission): Either[String, OphanIds] = Right(a.ophanIds)
 
-      override def buildAcquisition(a: AcquisitionSubmission): Either[String, Acquisition] =
-        Either.right(a.acquisition)
+      override def buildAcquisition(a: AcquisitionSubmission): Either[String, Acquisition] = Right(a.acquisition)
     }
-}
-
-/**
-  * Type class for creating an acquisition submission from an arbitrary data type.
-  */
-@typeclass trait AcquisitionSubmissionBuilder[A] {
-
-  import cats.syntax.either._
-
-  def buildOphanIds(a: A): Either[BuildError, OphanIds]
-
-  def buildAcquisition(a: A): Either[BuildError, Acquisition]
-
-  def asAcquisitionSubmission(a: A): Either[BuildError, AcquisitionSubmission] =
-    (for {
-      ophanIds <- buildOphanIds(a)
-      acquisition <- buildAcquisition(a)
-    } yield AcquisitionSubmission(ophanIds, acquisition))
 }

--- a/src/main/scala/com/gu/acquisition/model/AcquisitionSubmission.scala
+++ b/src/main/scala/com/gu/acquisition/model/AcquisitionSubmission.scala
@@ -1,6 +1,6 @@
 package com.gu.acquisition.model
 
-import com.gu.acquisition.services.OphanServiceError
+import com.gu.acquisition.services.{AcquisitionSubmissionProcessor, BuildError, OphanServiceError, ProcessError}
 import com.gu.acquisition.services.OphanServiceError.SubmissionBuildError
 import ophan.thrift.event.Acquisition
 import play.api.libs.json.{Reads, Writes, Json => PlayJson}
@@ -45,13 +45,13 @@ object AcquisitionSubmission {
 
   import cats.syntax.either._
 
-  def buildOphanIds(a: A): Either[String, OphanIds]
+  def buildOphanIds(a: A): Either[BuildError, OphanIds]
 
-  def buildAcquisition(a: A): Either[String, Acquisition]
+  def buildAcquisition(a: A): Either[BuildError, Acquisition]
 
-  def asAcquisitionSubmission(a: A): Either[OphanServiceError, AcquisitionSubmission] =
+  def asAcquisitionSubmission(a: A): Either[BuildError, AcquisitionSubmission] =
     (for {
       ophanIds <- buildOphanIds(a)
       acquisition <- buildAcquisition(a)
-    } yield AcquisitionSubmission(ophanIds, acquisition)).leftMap(SubmissionBuildError)
+    } yield AcquisitionSubmission(ophanIds, acquisition))
 }

--- a/src/main/scala/com/gu/acquisition/model/OphanIds.scala
+++ b/src/main/scala/com/gu/acquisition/model/OphanIds.scala
@@ -1,0 +1,21 @@
+package com.gu.acquisition.model
+
+import play.api.libs.json.{Reads, Writes, Json => PlayJson}
+
+/**
+  * Ids to be included in requests to Ophan.
+  */
+case class OphanIds(pageviewId: String, visitId: Option[String], browserId: Option[String])
+
+object OphanIds {
+  import io.circe._
+  import io.circe.generic.semiauto._
+
+  implicit val decoder: Decoder[OphanIds] = deriveDecoder[OphanIds]
+
+  implicit val encoder: Encoder[OphanIds] = deriveEncoder[OphanIds]
+
+  implicit val reads: Reads[OphanIds] = PlayJson.reads[OphanIds]
+
+  implicit val writes: Writes[OphanIds] = PlayJson.writes[OphanIds]
+}

--- a/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
+++ b/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
@@ -4,12 +4,10 @@ import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto._
 import ophan.thrift.componentEvent.ComponentType
 import ophan.thrift.event.{AbTest, AcquisitionSource}
-import play.api.libs.json.{Json, Reads, Writes}
+import play.api.libs.json.{Reads, Writes, Json => PlayJson}
 
 /**
   * Model for acquisition data passed by the referrer.
-  * This should be included in the request to the contribution website as part of the query string: acquisitionData={}
-  * The value should be the data encoded using Json in the canonical way, and then percent encoded.
   */
 case class ReferrerAcquisitionData(
     campaignCode: Option[String],
@@ -18,9 +16,6 @@ case class ReferrerAcquisitionData(
     componentId: Option[String],
     componentType: Option[ComponentType],
     source: Option[AcquisitionSource],
-    // Used to store the option of the client being in a test on the referring page,
-    // that resulted on them landing on the contributions page.
-    // e.g. they clicked the contribute link in an Epic AB test.
     abTest: Option[AbTest]
 )
 
@@ -34,7 +29,7 @@ object ReferrerAcquisitionData {
 
   implicit val referrerAcquisitionDataEncoder: Encoder[ReferrerAcquisitionData] = deriveEncoder[ReferrerAcquisitionData]
 
-  implicit val referrerAcquisitionDataReads: Reads[ReferrerAcquisitionData] = Json.reads[ReferrerAcquisitionData]
+  implicit val referrerAcquisitionDataReads: Reads[ReferrerAcquisitionData] = PlayJson.reads[ReferrerAcquisitionData]
 
-  implicit val referrerAcquisitionDataWrites: Writes[ReferrerAcquisitionData] = Json.writes[ReferrerAcquisitionData]
+  implicit val referrerAcquisitionDataWrites: Writes[ReferrerAcquisitionData] = PlayJson.writes[ReferrerAcquisitionData]
 }

--- a/src/main/scala/com/gu/acquisition/model/errors/OphanServiceError.scala
+++ b/src/main/scala/com/gu/acquisition/model/errors/OphanServiceError.scala
@@ -7,11 +7,11 @@ sealed trait OphanServiceError extends Throwable
 object OphanServiceError {
 
   case class BuildError(message: String) extends OphanServiceError {
-    override def getMessage: String = ""
+    override def getMessage: String = s"Acquisition submission build error: $message"
   }
 
   case class NetworkFailure(underlying: Throwable) extends OphanServiceError {
-    override def getMessage: String = underlying.getMessage
+    override def getMessage: String = s"Ophan network failure: ${underlying.getMessage}"
   }
 
   case class ResponseUnsuccessful(failedResponse: HttpResponse) extends OphanServiceError {

--- a/src/main/scala/com/gu/acquisition/model/errors/OphanServiceError.scala
+++ b/src/main/scala/com/gu/acquisition/model/errors/OphanServiceError.scala
@@ -1,0 +1,21 @@
+package com.gu.acquisition.model.errors
+
+import akka.http.scaladsl.model.HttpResponse
+
+sealed trait OphanServiceError extends Throwable
+
+object OphanServiceError {
+
+  case class BuildError(message: String) extends OphanServiceError {
+    override def getMessage: String = ""
+  }
+
+  case class NetworkFailure(underlying: Throwable) extends OphanServiceError {
+    override def getMessage: String = underlying.getMessage
+  }
+
+  case class ResponseUnsuccessful(failedResponse: HttpResponse) extends OphanServiceError {
+    override def getMessage: String = s"Ophan HTTP request failed: ${failedResponse.status}"
+  }
+}
+

--- a/src/main/scala/com/gu/acquisition/services/DefaultOphanService.scala
+++ b/src/main/scala/com/gu/acquisition/services/DefaultOphanService.scala
@@ -1,0 +1,78 @@
+package com.gu.acquisition.services
+
+import cats.data.EitherT
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.Uri.Query
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{Cookie, HttpCookiePair}
+import akka.stream.Materializer
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.OphanServiceError
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+
+import scala.collection.immutable.Seq
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Build an acquisition submission, and submit it to the Ophan endpoint specified in the class constructor.
+  * Uses Akka Http for executing the Http request.
+  */
+class DefaultOphanService(val endpoint: Uri)(implicit system: ActorSystem, materializer: Materializer)
+  extends OphanService {
+  import DefaultOphanService._
+  import OphanServiceError._
+
+  private val additionalEndpoint = endpoint.copy(path = Uri.Path("/a.gif"))
+
+  private def buildRequest(submission: AcquisitionSubmission): RequestData = {
+    import com.gu.acquisition.instances.acquisition._
+    import io.circe.syntax._
+    import submission._
+
+    val params = Query("viewId" -> ophanIds.pageviewId, "acquisition" -> acquisition.asJson.noSpaces)
+
+    val cookies = List(
+      ophanIds.browserId.map(HttpCookiePair("bwid", _)),
+      ophanIds.visitId.map(HttpCookiePair("vsid", _))
+    ).flatten
+
+    RequestData(
+      HttpRequest(
+        uri = additionalEndpoint.withQuery(params),
+        headers = Seq(Cookie(cookies))
+      ),
+      submission
+    )
+  }
+
+  private def executeRequest(data: RequestData)(
+    implicit ec: ExecutionContext): EitherT[Future, OphanServiceError, AcquisitionSubmission] = {
+
+    import cats.instances.future._
+    import cats.syntax.applicativeError._
+
+    Http().singleRequest(data.request).attemptT
+      .leftMap(NetworkFailure)
+      .subflatMap { response =>
+        if (response.status.isSuccess) Right(data.submission)
+        else Left(ResponseUnsuccessful(response))
+      }
+  }
+
+  override def submit[A : AcquisitionSubmissionBuilder](a: A)(
+    implicit ec: ExecutionContext): EitherT[Future, OphanServiceError, AcquisitionSubmission] = {
+
+    import cats.instances.future._
+    import cats.syntax.either._
+    import AcquisitionSubmissionBuilder.ops._
+
+    a.asAcquisitionSubmission.toEitherT.map(buildRequest).flatMap(executeRequest)
+  }
+}
+
+object DefaultOphanService {
+
+  private case class RequestData(request: HttpRequest, submission: AcquisitionSubmission)
+}
+

--- a/src/main/scala/com/gu/acquisition/services/MockOphanService.scala
+++ b/src/main/scala/com/gu/acquisition/services/MockOphanService.scala
@@ -1,0 +1,25 @@
+package com.gu.acquisition.services
+import cats.data.EitherT
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.OphanServiceError
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Build an acquisition submission, but don't actually send it to an Ophan endpoint.
+  * Useful for e.g. test users.
+  */
+object MockOphanService extends OphanService {
+
+  override def submit[A: AcquisitionSubmissionBuilder](a: A)(
+    implicit ec: ExecutionContext): EitherT[Future, OphanServiceError, AcquisitionSubmission] = {
+
+    import cats.instances.future._
+    import cats.syntax.either._
+    import AcquisitionSubmissionBuilder.ops._
+
+    // Left map to lift the build error into a processing error.
+    a.asAcquisitionSubmission.toEitherT.leftMap(err => err: OphanServiceError)
+  }
+}

--- a/src/main/scala/com/gu/acquisition/services/OphanService.scala
+++ b/src/main/scala/com/gu/acquisition/services/OphanService.scala
@@ -1,132 +1,31 @@
 package com.gu.acquisition.services
 
-import cats.data.EitherT
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.Uri.Query
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.{Cookie, HttpCookiePair}
+import akka.http.scaladsl.model.Uri
 import akka.stream.Materializer
-import com.gu.acquisition.model.{AcquisitionSubmission, AcquisitionSubmissionBuilder}
-import com.gu.acquisition.services.OphanServiceError.NetworkFailure
+import cats.data.EitherT
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.OphanServiceError
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
 
-import scala.collection.immutable.Seq
 import scala.concurrent.{ExecutionContext, Future}
-import scala.reflect.ClassTag
 
-sealed trait OphanServiceError extends Throwable
+/**
+  * Service for sending acquisition events to Ophan.
+  */
+trait OphanService {
 
-object OphanServiceError {
-
-  case class SubmissionBuildError(message: String) extends OphanServiceError {
-    override def getMessage: String = message
-  }
-
-  case class NetworkFailure(underlying: Throwable) extends OphanServiceError {
-    override def getMessage: String = underlying.getMessage
-  }
-
-  case class ResponseUnsuccessful(failedResponse: HttpResponse) extends OphanServiceError {
-    override def getMessage: String = s"Ophan HTTP request failed: ${failedResponse.status}"
-  }
-
-}
-
-
-sealed trait ProcessError extends Exception
-
-case class BuildError(message: String) extends ProcessError {
-  override def getMessage: String = s"Acquisition submission build error: $message"
-}
-
-case class CustomError[E <: Exception : ClassTag](error: E) extends ProcessError {
-  override def getMessage: String = s"Custom acquisition submission error: ${error.getMessage} ${classOf[error]}"
-}
-
-trait AcquisitionSubmissionProcessor {
-
-  def process[A : AcquisitionSubmissionBuilder](a: A)
-    (implicit ec: ExecutionContext): EitherT[Future, ProcessError, AcquisitionSubmission]
+  def submit[A : AcquisitionSubmissionBuilder](a: A)(
+    implicit ec: ExecutionContext): EitherT[Future, OphanServiceError, AcquisitionSubmission]
 }
 
 object OphanService {
 
   val prodEndpoint: Uri = "https://ophan.theguardian.com"
 
-  def prod(implicit system: ActorSystem, materializer: Materializer): OphanService =
-    new HttpOphanService(prodEndpoint)
+  def prod(implicit system: ActorSystem, materializer: Materializer): DefaultOphanService =
+    new DefaultOphanService(prodEndpoint)
 
-  def apply(endpoint: Uri)(implicit system: ActorSystem, materializer: Materializer): OphanService =
-    new HttpOphanService(endpoint)
-}
-
-class OphanSubmission extends AcquisitionSubmissionProcessor[OphanServiceError] {
-  /**
-    * Submit an acquisition to Ophan.
-    *
-    * If browserId or viewId are missing, then it is not guaranteed they will be available
-    * for the respective acquisition in the data lake table: acquisitions.
-    * This will make certain reporting and analysis harder.
-    * If possible they should be included.
-    */
-  override def process[A: AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext) = ???
-}
-
-
-private class HttpOphanService(val endpoint: Uri)(implicit system: ActorSystem, materializer: Materializer)
-  extends OphanService {
-
-  private val additionalEndpoint = endpoint.copy(path = Uri.Path("/a.gif"))
-
-  private def buildRequest(submission: AcquisitionSubmission): HttpRequest = {
-    import com.gu.acquisition.instances.acquisition._
-    import io.circe.syntax._
-    import submission._
-
-    val params = Query("viewId" -> ophanIds.pageviewId, "acquisition" -> acquisition.asJson.noSpaces)
-
-    val cookies = List(
-      ophanIds.browserId.map(HttpCookiePair("bwid", _)),
-      ophanIds.visitId.map(HttpCookiePair("vsid", _))
-    ).flatten
-
-    HttpRequest(
-      uri = additionalEndpoint.withQuery(params),
-      headers = Seq(Cookie(cookies))
-    )
-  }
-
-  private def executeRequest(
-      request: HttpRequest
-  )(implicit ec: ExecutionContext): EitherT[Future, OphanServiceError, HttpResponse] = {
-    import cats.instances.future._
-    import cats.syntax.applicativeError._
-    import cats.syntax.either._
-
-    Http().singleRequest(request).attemptT
-      .leftMap(OphanServiceError.NetworkFailure)
-      .subflatMap { res =>
-        if (res.status.isSuccess) Either.right(res)
-        else Either.left(OphanServiceError.ResponseUnsuccessful(res))
-      }
-  }
-
-  /**
-    * Submit an acquisition to Ophan.
-    *
-    * If browserId or viewId are missing, then it is not guaranteed they will be available
-    * for the respective acquisition in the data lake table: acquisitions.
-    * This will make certain reporting and analysis harder.
-    * If possible they should be included.
-    */
-  def submit[A : AcquisitionSubmissionBuilder](a: A)
-    (implicit ec: ExecutionContext): EitherT[Future, OphanServiceError, AcquisitionSubmission] = {
-    import cats.instances.future._
-    import cats.syntax.either._
-    import com.gu.acquisition.model.AcquisitionSubmissionBuilder.ops._
-
-    a.asAcquisitionSubmission.toEitherT
-      .map(buildRequest)
-      .flatMap(executeRequest)
-  }
+  def apply(endpoint: Uri)(implicit system: ActorSystem, materializer: Materializer): DefaultOphanService =
+    new DefaultOphanService(endpoint)
 }

--- a/src/main/scala/com/gu/acquisition/syntax/iterable.scala
+++ b/src/main/scala/com/gu/acquisition/syntax/iterable.scala
@@ -1,0 +1,17 @@
+package com.gu.acquisition.syntax
+
+import com.gu.acquisition.typeclasses.AbTestConverter
+import ophan.thrift.event.AbTestInfo
+
+trait IterableSyntax {
+
+  implicit def iterableSyntax[A](as: Iterable[A]): IterableOps[A] = new IterableOps[A](as)
+}
+
+final class IterableOps[A](val as: Iterable[A]) extends AnyVal {
+
+  def asAbTestInfo(implicit converter: AbTestConverter[A]): AbTestInfo = {
+    import AbTestConverter.ops._
+    AbTestInfo(as.map(_.asAbTest).toSet)
+  }
+}

--- a/src/main/scala/com/gu/acquisition/syntax/package.scala
+++ b/src/main/scala/com/gu/acquisition/syntax/package.scala
@@ -1,14 +1,8 @@
 package com.gu.acquisition
 
-import ophan.thrift.event.AbTestInfo
-import utils.AbTestConverter
-
 package object syntax {
-  implicit final def iterableSyntax[A](as: Iterable[A]): IterableOps[A] = new IterableOps(as)
-}
 
-final class IterableOps[A](val as: Iterable[A]) extends AnyVal {
-  def asAbTestInfo(implicit converter: AbTestConverter[A]): AbTestInfo = {
-    AbTestInfo(as.map(converter.asAbTest).toSet)
-  }
+  object all extends IterableSyntax
+
+  object iterable extends IterableSyntax
 }

--- a/src/main/scala/com/gu/acquisition/typeclasses/AbTestConverter.scala
+++ b/src/main/scala/com/gu/acquisition/typeclasses/AbTestConverter.scala
@@ -1,7 +1,7 @@
-package com.gu.acquisition.utils
+package com.gu.acquisition.typeclasses
 
 import ophan.thrift.event.AbTest
-import simulacrum._
+import simulacrum.typeclass
 
 @typeclass trait AbTestConverter[A] {
   def asAbTest(a: A): AbTest

--- a/src/main/scala/com/gu/acquisition/typeclasses/AcquisitionSubmissionBuilder.scala
+++ b/src/main/scala/com/gu/acquisition/typeclasses/AcquisitionSubmissionBuilder.scala
@@ -1,0 +1,24 @@
+package com.gu.acquisition.typeclasses
+
+import com.gu.acquisition.model.errors.OphanServiceError.BuildError
+import com.gu.acquisition.model.{AcquisitionSubmission, OphanIds}
+import ophan.thrift.event.Acquisition
+import simulacrum.typeclass
+
+/**
+  * Type class for creating an acquisition submission from an arbitrary data type.
+  */
+@typeclass trait AcquisitionSubmissionBuilder[A] {
+
+  import cats.syntax.either._
+
+  def buildOphanIds(a: A): Either[String, OphanIds]
+
+  def buildAcquisition(a: A): Either[String, Acquisition]
+
+  def asAcquisitionSubmission(a: A): Either[BuildError, AcquisitionSubmission] =
+    (for {
+      ophanIds <- buildOphanIds(a)
+      acquisition <- buildAcquisition(a)
+    } yield AcquisitionSubmission(ophanIds, acquisition)).leftMap(BuildError)
+}

--- a/src/main/scala/com/gu/acquisition/utils/CurrencyUtils.scala
+++ b/src/main/scala/com/gu/acquisition/utils/CurrencyUtils.scala
@@ -1,6 +1,0 @@
-package com.gu.acquisition.utils
-
-object CurrencyUtils {
-  def formatAmount(amount: Double, currencyCode: String): Double =
-    if (currencyCode.equalsIgnoreCase("jpy")) amount else amount / 100
-}

--- a/src/test/scala/com/gu/acquisition/app/AcquisitionSubmissionSimulation.scala
+++ b/src/test/scala/com/gu/acquisition/app/AcquisitionSubmissionSimulation.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
 import akka.stream.{ActorMaterializer, Materializer}
 import com.gu.acquisition.model.{AcquisitionSubmission, OphanIds}
-import com.gu.acquisition.services.OphanService
+import com.gu.acquisition.services.DefaultOphanService
 import com.typesafe.scalalogging.StrictLogging
 import ophan.thrift.event.{Acquisition, PaymentFrequency, PaymentProvider}
 
@@ -39,8 +39,9 @@ object BasicMockDataGenerator extends MockDataGenerator {
     )
 }
 
-class AcquisitionSubmissionSimulator(service: OphanService, generator: MockDataGenerator)(implicit ec: ExecutionContext)
-  extends StrictLogging {
+class AcquisitionSubmissionSimulator(service: DefaultOphanService, generator: MockDataGenerator)(
+  implicit ec: ExecutionContext) extends StrictLogging {
+
   import cats.instances.future._
 
   def submit(): Future[Unit] = {
@@ -61,7 +62,7 @@ object AcquisitionSubmissionSimulator {
     materializer: Materializer
   ): AcquisitionSubmissionSimulator = {
 
-    val service = new OphanService(endpoint)
+    val service = new DefaultOphanService(endpoint)
     new AcquisitionSubmissionSimulator(service, generator)
   }
 }

--- a/src/test/scala/com/gu/acquisition/typeclasses/AbTestConverterSpec.scala
+++ b/src/test/scala/com/gu/acquisition/typeclasses/AbTestConverterSpec.scala
@@ -1,9 +1,9 @@
-package com.gu.acquisition.utils
+package com.gu.acquisition.typeclasses
 
 import ophan.thrift.event.{AbTest, AbTestInfo}
 import org.scalatest.{Matchers, WordSpecLike}
 
-class AbTestConvertorSpec extends WordSpecLike with Matchers {
+class AbTestConverterSpec extends WordSpecLike with Matchers {
 
   case class ExampleABTest(testName: String, variantName: String)
 
@@ -16,7 +16,7 @@ class AbTestConvertorSpec extends WordSpecLike with Matchers {
   "An AB test info instance" should {
 
     "be able to be created from a collection of a class with an implicit AB test converter in scope" in {
-      import com.gu.acquisition.syntax._
+      import com.gu.acquisition.syntax.iterable._
 
       val tests = List(
         ExampleABTest("test1", "control1"),


### PR DESCRIPTION
@desbo in the end, moved back to Ophan services instead of something more generic, as `AcquisitionSubmission` is modelled with Ophan explicitly in mind. So it was just a case of having a generic trait, and then having default and mock implementations.

Apart from that, I've just structured the package a bit more consistently as it starting to grow from what essentially was just one class.

Don't know what you think of the version should be - `v2.0.0-rc.3` 😂 ?! At the moment its `V2.0.0-SNAPSHOT` and the work in `support-models` and `support-workers` use this dependency.