### PR TITLE
Move to OK Http for Http requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
   "com.github.mpilquist" %% "simulacrum" % "0.10.0",
   "com.gu" %% "fezziwig" % "0.6",
   "com.gu" %% "ophan-event-model" % "1.0.0",
-  "com.typesafe.akka" %% "akka-http" % "10.0.10",
+  "com.squareup.okhttp3" % "okhttp" % "3.9.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
   "io.circe" %% "circe-core" % "0.8.0",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 name := "acquisition-event-producer"
 
-version := "2.0.0-rc.3"
+version := "2.0.0-rc.4"
 
 scalaVersion := "2.11.11"
 

--- a/src/main/scala/com/gu/acquisition/model/errors/OphanServiceError.scala
+++ b/src/main/scala/com/gu/acquisition/model/errors/OphanServiceError.scala
@@ -1,6 +1,8 @@
 package com.gu.acquisition.model.errors
 
-import akka.http.scaladsl.model.HttpResponse
+import java.io.IOException
+
+import okhttp3.Response
 
 sealed trait OphanServiceError extends Throwable
 
@@ -10,12 +12,12 @@ object OphanServiceError {
     override def getMessage: String = s"Acquisition submission build error: $message"
   }
 
-  case class NetworkFailure(underlying: Throwable) extends OphanServiceError {
+  case class NetworkFailure(underlying: IOException) extends OphanServiceError {
     override def getMessage: String = s"Ophan network failure: ${underlying.getMessage}"
   }
 
-  case class ResponseUnsuccessful(failedResponse: HttpResponse) extends OphanServiceError {
-    override def getMessage: String = s"Ophan HTTP request failed: ${failedResponse.status}"
+  case class ResponseUnsuccessful(failedResponse: Response) extends OphanServiceError {
+    override def getMessage: String = s"Ophan HTTP request failed: ${failedResponse.code}"
   }
 }
 

--- a/src/test/scala/com/gu/acquisition/services/DefaultOphanServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/DefaultOphanServiceSpec.scala
@@ -1,0 +1,48 @@
+package com.gu.acquisition.services
+
+import com.gu.acquisition.model.{AcquisitionSubmission, OphanIds}
+import okhttp3.OkHttpClient
+import ophan.thrift.event._
+import org.scalatest.{Matchers, WordSpecLike}
+
+class DefaultOphanServiceSpec extends WordSpecLike with Matchers {
+
+  implicit val client = new OkHttpClient()
+
+  val service: DefaultOphanService = OphanService.prod
+
+  val submission: AcquisitionSubmission = AcquisitionSubmission(
+    OphanIds("pageviewId", Some("visitId"), Some("browserId")),
+    Acquisition(
+      product = ophan.thrift.event.Product.Contribution,
+      paymentFrequency = PaymentFrequency.OneOff,
+      currency = "GBP",
+      amount = 20d,
+      amountInGBP = None,
+      paymentProvider = Some(PaymentProvider.Stripe),
+      campaignCode = None,
+      abTests = Some(AbTestInfo(Set(AbTest("test_name", "variant_name")))),
+      countryCode = Some("US"),
+      referrerPageViewId = None,
+      referrerUrl = None,
+      componentId = None,
+      componentTypeV2 = None,
+      source = None
+    )
+  )
+
+  "A default Ophan service" should {
+
+    "build a correct request" in {
+
+      val request = service.buildRequest(submission).request
+
+      request.method shouldEqual "GET"
+      request.header("Cookie") shouldEqual "vsid=visitId;bwid=browserId"
+
+      // TODO: check non-strict encoding is OK
+      request.url().url().toString shouldEqual
+        "https://ophan.theguardian.com/a.gif?viewId=pageviewId&acquisition={%22product%22:%22CONTRIBUTION%22,%22paymentFrequency%22:%22ONE_OFF%22,%22currency%22:%22GBP%22,%22amount%22:20.0,%22paymentProvider%22:%22STRIPE%22,%22abTests%22:{%22tests%22:[{%22name%22:%22test_name%22,%22variant%22:%22variant_name%22}]},%22countryCode%22:%22US%22}"
+    }
+  }
+}


### PR DESCRIPTION
By request from @rupertbates in [this](https://github.com/guardian/support-workers/pull/60) pull request.

Tested against Ophan running locally, and acquisition events are written to Elasticsaerch aok.