### PR TITLE
Revert to bintray from sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,35 +7,7 @@ scalaVersion := "2.11.11"
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
-publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (isSnapshot.value)
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("releases" at nexus + "service/local/staging/deploy/maven2")
-}
-
-
-scmInfo := Some(ScmInfo(
-  url("https://github.com/guardian/acquisition-event-producer"),
-  "scm:git:git@github.com:guardian/acquisition-event-producer.git"
-))
-
-
-sonatypeProfileName := "com.gu"
-
-pomExtra := (
-  <url>https://github.com/guardian/acquisition-event-producer</url>
-    <developers>
-      <developer>
-        <id>desbo</id>
-        <name>Sam Desborough</name>
-        <url>https://github.com/desbo</url>
-      </developer>
-    </developers>
-  )
-
-licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+resolvers += Resolver.bintrayRepo("guardian", "ophan")
 
 libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.3",
@@ -52,4 +24,6 @@ libraryDependencies ++= Seq(
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 organization := "com.gu"
+bintrayOrganization := Some("guardian")
+bintrayRepository := "ophan"
 publishMavenStyle := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,1 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")


### PR DESCRIPTION
Currently there's an issue publishing to Sonatype. Revert to bintray for now, so that `v2.0.0-rc.5` can be released.