### PR TITLE
remove version from build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 
 name := "acquisition-event-producer"
 
-version := "2.0.0"
-
 scalaVersion := "2.11.11"
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)


### PR DESCRIPTION
version in build.sbt unnecessary as we are using the sbt release plugin.