### PR TITLE
Add abTests to ReferrerAcquisitionData

### DIFF
--- a/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
+++ b/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
@@ -17,7 +17,7 @@ case class ReferrerAcquisitionData(
     componentType: Option[ComponentType],
     source: Option[AcquisitionSource],
     abTest: Option[AbTest], //Deprecated, please use abTests
-    abTests: Option[Seq[AbTest]]
+    abTests: Option[Set[AbTest]]
 )
 
 object ReferrerAcquisitionData {

--- a/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
+++ b/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
@@ -16,7 +16,8 @@ case class ReferrerAcquisitionData(
     componentId: Option[String],
     componentType: Option[ComponentType],
     source: Option[AcquisitionSource],
-    abTest: Option[AbTest]
+    abTest: Option[AbTest], //Deprecated, please use abTests
+    abTests: Option[Seq[AbTest]]
 )
 
 object ReferrerAcquisitionData {

--- a/src/test/scala/com/gu/acquisition/model/ReferrerAcquisitionSpec.scala
+++ b/src/test/scala/com/gu/acquisition/model/ReferrerAcquisitionSpec.scala
@@ -16,7 +16,7 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
     componentType = Some(ComponentType.AcquisitionsEpic),
     source = Some(AcquisitionSource.GuardianWeb),
     abTest = Some(AbTest("test_name", "variant_name")),
-    abTests = Some(Seq(AbTest("test_name", "variant_name"), AbTest("test_name2", "variant_name2")))
+    abTests = Some(Set(AbTest("test_name", "variant_name"), AbTest("test_name2", "variant_name2")))
   )
 
   val referrerAcquisitionCJson: CJson = CJson.obj(

--- a/src/test/scala/com/gu/acquisition/model/ReferrerAcquisitionSpec.scala
+++ b/src/test/scala/com/gu/acquisition/model/ReferrerAcquisitionSpec.scala
@@ -15,7 +15,8 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
     componentId = Some("component_id"),
     componentType = Some(ComponentType.AcquisitionsEpic),
     source = Some(AcquisitionSource.GuardianWeb),
-    abTest = Some(AbTest("test_name", "variant_name"))
+    abTest = Some(AbTest("test_name", "variant_name")),
+    abTests = Some(Seq(AbTest("test_name", "variant_name"), AbTest("test_name2", "variant_name2")))
   )
 
   val referrerAcquisitionCJson: CJson = CJson.obj(
@@ -28,6 +29,16 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
     "abTest" -> CJson.obj(
       "name" -> CJson.fromString("test_name"),
       "variant" -> CJson.fromString("variant_name")
+    ),
+    "abTests" -> CJson.arr(
+      CJson.obj(
+        "name" -> CJson.fromString("test_name"),
+        "variant" -> CJson.fromString("variant_name")
+      ),
+      CJson.obj(
+        "name" -> CJson.fromString("test_name2"),
+        "variant" -> CJson.fromString("variant_name2")
+      )
     )
   )
 
@@ -41,6 +52,16 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
     "abTest" -> PJson.obj(
       "name" -> "test_name",
       "variant" -> "variant_name"
+    ),
+    "abTests" -> PJson.arr(
+      PJson.obj(
+        "name" -> "test_name",
+        "variant" -> "variant_name"
+      ),
+      PJson.obj(
+        "name" -> "test_name2",
+        "variant" -> "variant_name2"
+      )
     )
   )
 


### PR DESCRIPTION
This PR adds the field `abTests` to the ReferrerAcquisitionData class. It is to replace the current `abTest` field, which is now deprecated and will be removed in the near future. 

The reason for this change is that we realised that sometimes we need to send information about more than one AB test to the acquisition sites. An example would be when coming to the Support Frontend from and Epic test, then being put into a Support Frontend copy test and sending that information through to the subs site. In this situation, we need to send information about 2 AB tests through to the subs site. 