### PR TITLE
Publish for multiple versions of `play-json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.0.4
+* change release process to publish 3 different packages for play-json 2.4, 2.5 and 2.6
+
 # v2.0.0-rc2
 * add `AcquisitionSubmission` to represent a combination of an `Acquisition` and `OphanIds`
 * add the `AcquisitionSubmissionBuilder` type class for generating acquisition submissions

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# acquisition event producer
+A tool to submit Acquisition events to Ophan.
+
+## usage 
+### in Play projects
+Add a dependency on the version that corresponds to your version of Play:
+
+`libraryDependencies += "com.gu" %% "acquisition-event-producer-play24" % "2.0.4"`
+`libraryDependencies += "com.gu" %% "acquisition-event-producer-play25" % "2.0.4"`
+`libraryDependencies += "com.gu" %% "acquisition-event-producer-play26" % "2.0.4"`
+
+### in projects that don't use Play
+Import any of the above three projects - the same Circe encoders/decoders are included in each one.
+ 
+Create an instance of `AcquisitionSubmissionBuilder` in your project. Pass this to `submit` in either `DefaultOphanService` or `MockOphanService` (depending on whether you're in test or live mode) build and (in the case of `DefaultOphanService`) submit the event.

--- a/build.sbt
+++ b/build.sbt
@@ -1,25 +1,54 @@
+import sbt.Keys.organization
 
-name := "acquisition-event-producer"
+val commonSettings: Seq[SettingsDefinition] = Seq(
+  scalaVersion := "2.11.11",
 
-scalaVersion := "2.11.11"
+  libraryDependencies := Seq(
+    "ch.qos.logback" % "logback-classic" % "1.2.3",
+    "com.github.mpilquist" %% "simulacrum" % "0.10.0",
+    "com.gu" %% "fezziwig" % "0.6",
+    "com.gu" %% "ophan-event-model" % "0.0.2" excludeAll(ExclusionRule(organization = "com.typesafe.play")),
+    "com.squareup.okhttp3" % "okhttp" % "3.9.0",
+    "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
+    "io.circe" %% "circe-core" % "0.8.0",
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+    "org.scalactic" %% "scalactic" % "3.0.1",
+    "org.typelevel" %% "cats" % "0.9.0",
+    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+  ),
 
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-
-libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  "com.github.mpilquist" %% "simulacrum" % "0.10.0",
-  "com.gu" %% "fezziwig" % "0.6",
-  "com.gu" %% "ophan-event-model" % "0.0.2",
-  "com.squareup.okhttp3" % "okhttp" % "3.9.0",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
-  "io.circe" %% "circe-core" % "0.8.0",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "org.scalactic" %% "scalactic" % "3.0.1",
-  "org.typelevel" %% "cats" % "0.9.0"
+  licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
+  organization := "com.gu",
+  bintrayOrganization := Some("guardian"),
+  bintrayRepository := "ophan",
+  publishMavenStyle := true
 )
 
-licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
-organization := "com.gu"
-bintrayOrganization := Some("guardian")
-bintrayRepository := "ophan"
-publishMavenStyle := true
+// This project is compiled against multiple versions of `play-json` to aid compatibility.
+// The root build is published as `acquisition-event-producer` and uses play-json 2.4;
+// we also publish builds for play-json 2.5 and 2.6. The directories for these builds
+// (`play25`, `play25` etc) aren't real files but need to be specified in this way to
+// emulate separate projects.
+lazy val root = (project in file("."))
+  .aggregate(eventProducerPlayJson25, eventProducerPlayJson26)
+  .settings(commonSettings: _*)
+  .settings(
+    libraryDependencies ++= Seq("com.typesafe.play" %% "play-json" % "2.4.11"),
+    name := "acquisition-event-producer"
+  )
+
+lazy val eventProducerPlayJson25 = (project in file("play25"))
+  .settings(commonSettings: _*)
+  .settings(
+    sourceDirectory := baseDirectory.value / "../src",
+    libraryDependencies ++= Seq("com.typesafe.play" %% "play-json" % "2.5.18"),
+    name := "acquisition-event-producer-play25"
+  )
+
+lazy val eventProducerPlayJson26 = (project in file("play26"))
+  .settings(commonSettings: _*)
+  .settings(
+    sourceDirectory := baseDirectory.value / "../src",
+    libraryDependencies ++= Seq("com.typesafe.play" %% "play-json" % "2.6.7"),
+    name := "acquisition-event-producer-play26"
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val root = (project in file("."))
   .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Seq("com.typesafe.play" %% "play-json" % "2.4.11"),
-    name := "acquisition-event-producer"
+    name := "acquisition-event-producer-play24"
   )
 
 lazy val eventProducerPlayJson25 = (project in file("play25"))


### PR DESCRIPTION
I've updated build.sbt so it contains 3 projects for `play-json` 2.4, 2.5 and 2.6, published as `acquisition-event-producer-play24`, `acquisition-event-producer-play25` and `acquisition-event-producer-play26`. The root (`play24`) project aggregates the other two, so any command you run on root will also run against them. Publishing all 3 packages should still only require `sbt release`.