### PR TITLE
update cats to avoid binary incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.0.0
 * change to use cats version 1.0 (this can [cause binary incompatibilities that only show up in prod](https://github.com/guardian/subscriptions-frontend/pull/1067), beware)
+* update version of circe to match (and fezziwig to avoid a further binary incompability)
 
 # v2.0.4
 * change release process to publish 3 different packages for play-json 2.4, 2.5 and 2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.1.0
+* change to use cats version 1.0 (this can [cause binary incompatibilities that only show up in prod](https://github.com/guardian/subscriptions-frontend/pull/1067), beware)
+
 # v2.0.4
 * change release process to publish 3 different packages for play-json 2.4, 2.5 and 2.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v2.1.0
+# v3.0.0
 * change to use cats version 1.0 (this can [cause binary incompatibilities that only show up in prod](https://github.com/guardian/subscriptions-frontend/pull/1067), beware)
 
 # v2.0.4

--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,10 @@ val commonSettings: Seq[SettingsDefinition] = Seq(
     "com.gu" %% "ophan-event-model" % "0.0.2" excludeAll(ExclusionRule(organization = "com.typesafe.play")),
     "com.squareup.okhttp3" % "okhttp" % "3.9.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
-    "io.circe" %% "circe-core" % "0.8.0",
+    "io.circe" %% "circe-core" % "0.9.1",
     "org.scalatest" %% "scalatest" % "3.0.1" % "test",
     "org.scalactic" %% "scalactic" % "3.0.1",
-    "org.typelevel" %% "cats" % "0.9.0",
+    "org.typelevel" %% "cats-core" % "1.0.1",
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   ),
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val commonSettings: Seq[SettingsDefinition] = Seq(
   libraryDependencies := Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.github.mpilquist" %% "simulacrum" % "0.10.0",
-    "com.gu" %% "fezziwig" % "0.6",
+    "com.gu" %% "fezziwig" % "0.8",
     "com.gu" %% "ophan-event-model" % "0.0.2" excludeAll(ExclusionRule(organization = "com.typesafe.play")),
     "com.squareup.okhttp3" % "okhttp" % "3.9.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",


### PR DESCRIPTION
The binary incompatibility in cats of this vs the guardian google auth libs caused a NoClass found exception when someone tried to checkout subs.  Fortunately the exception only happened after the checkout completed but before the thank you page displayed so we still got the subscription, although it wouldn't have been tracked (I think it happened twice last night before I rolled back).  Unfrotunately play's response to that error was to terminate the JVM instantly!  https://github.com/guardian/subscriptions-frontend/pull/1067

To avoid this untestable failure in prod, this code should be being run in dev/code modes too, not just in prod, but it should probably be sent to a dummy destination.  Otherwise there's a big chance for this only hitting in prod in future especially with binary incompatibility issues.  Is there a way to send events with a "DEV" flag on them rather than using a mock?

I had to update a couple of libraries as you can see, can anyone see any issue there?

@jranks123 @desbo looks like you guys made a few PRs in the past so perhaps you can review please?
@davidfurey fyi in case membership has this issue