### PR TITLE
Remove play-json 2.5.x and 2.4.x. Add Scala 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ Add a dependency on the package that corresponds to your version of Play:
 Import any of the above three projects - the same Circe encoders/decoders are included in each one.
  
 Create an instance of `AcquisitionSubmissionBuilder` in your project. Pass this to `submit` in either `DefaultOphanService` or `MockOphanService` (depending on whether you're in test or live mode) build and (in the case of `DefaultOphanService`) submit the event.
+
+## Scala 2.12 upgrade warnings
+
+Please note since March 2018 and version 4.x.x the library has been upgraded to use Scala 2.12.
+
+play-json 2.5.x and 2.4.x has no support for Scala 2.12 therefore play24 are play25 have been removed from he build.
+
+More info: https://mvnrepository.com/artifact/com.typesafe.play/play-json

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ A tool to submit Acquisition events to Ophan.
 ### in Play projects
 Add a dependency on the package that corresponds to your version of Play:
 
-`libraryDependencies += "com.gu" %% "acquisition-event-producer-play24" % "2.0.4"`
+`libraryDependencies += "com.gu" %% "acquisition-event-producer-play24" % "3.0.0"`
 
-`libraryDependencies += "com.gu" %% "acquisition-event-producer-play25" % "2.0.4"`
+`libraryDependencies += "com.gu" %% "acquisition-event-producer-play25" % "3.0.0"`
 
-`libraryDependencies += "com.gu" %% "acquisition-event-producer-play26" % "2.0.4"`
+**Play 2.4 and 2.5 are only supported up to version 3.x.x** (see Scala 2.12 upgrade warnings below)
+`libraryDependencies += "com.gu" %% "acquisition-event-producer-play26" % "4.0.0"`
 
 ### in projects that don't use Play
 Import any of the above three projects - the same Circe encoders/decoders are included in each one.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Create an instance of `AcquisitionSubmissionBuilder` in your project. Pass this 
 
 Please note since March 2018 and version 4.x.x the library has been upgraded to use Scala 2.12.
 
-play-json 2.5.x and 2.4.x has no support for Scala 2.12 therefore play24 are play25 have been removed from he build.
+play-json 2.5.x and 2.4.x has no support for Scala 2.12 therefore play24 are play25 have been removed from the build.
 
 More info: https://mvnrepository.com/artifact/com.typesafe.play/play-json

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
 import sbt.Keys.organization
 
 val commonSettings: Seq[SettingsDefinition] = Seq(
-  scalaVersion := "2.11.11",
+  scalaVersion := "2.12.4",
 
   libraryDependencies := Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.github.mpilquist" %% "simulacrum" % "0.10.0",
     "com.gu" %% "fezziwig" % "0.8",
-    "com.gu" %% "ophan-event-model" % "0.0.2" excludeAll(ExclusionRule(organization = "com.typesafe.play")),
+    "com.gu" %% "ophan-event-model" % "0.0.3" excludeAll(ExclusionRule(organization = "com.typesafe.play")),
     "com.squareup.okhttp3" % "okhttp" % "3.9.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
     "io.circe" %% "circe-core" % "0.9.1",
@@ -30,25 +30,9 @@ val commonSettings: Seq[SettingsDefinition] = Seq(
 // (`play25`, `play25` etc) aren't real files but need to be specified in this way to
 // emulate separate projects.
 lazy val root = (project in file("."))
-  .aggregate(eventProducerPlayJson25, eventProducerPlayJson26)
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= Seq("com.typesafe.play" %% "play-json" % "2.4.11"),
-    name := "acquisition-event-producer-play24"
-  )
-
-lazy val eventProducerPlayJson25 = (project in file("play25"))
-  .settings(commonSettings: _*)
-  .settings(
-    sourceDirectory := baseDirectory.value / "../src",
-    libraryDependencies ++= Seq("com.typesafe.play" %% "play-json" % "2.5.18"),
-    name := "acquisition-event-producer-play25"
-  )
-
-lazy val eventProducerPlayJson26 = (project in file("play26"))
-  .settings(commonSettings: _*)
-  .settings(
-    sourceDirectory := baseDirectory.value / "../src",
     libraryDependencies ++= Seq("com.typesafe.play" %% "play-json" % "2.6.7"),
     name := "acquisition-event-producer-play26"
   )
+


### PR DESCRIPTION
Since March 2018 and version 4.x.x the library has been upgraded to use Scala 2.12.

play-json 2.5.x and 2.4.x has no support for Scala 2.12 therefore play24 are play25 have been removed from he build.

More info: https://mvnrepository.com/artifact/com.typesafe.play/play-json