### PR TITLE
Add query parameters to ReferrerAcquisitionData

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val commonSettings: Seq[SettingsDefinition] = Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.github.mpilquist" %% "simulacrum" % "0.10.0",
     "com.gu" %% "fezziwig" % "0.8",
-    "com.gu" %% "ophan-event-model" % "0.0.3" excludeAll(ExclusionRule(organization = "com.typesafe.play")),
+    "com.gu" %% "ophan-event-model" % "0.0.6" excludeAll(ExclusionRule(organization = "com.typesafe.play")),
     "com.squareup.okhttp3" % "okhttp" % "3.9.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
     "io.circe" %% "circe-core" % "0.9.1",

--- a/src/main/scala/com/gu/acquisition/instances/package.scala
+++ b/src/main/scala/com/gu/acquisition/instances/package.scala
@@ -9,6 +9,7 @@ package object instances {
     with ComponentTypeInstances
     with PaymentFrequencyInstances
     with PaymentProviderInstances
+    with QueryParameterInstances
 
   object abTest extends AbTestInstances
   object abTestInfo extends AbTestInfoInstances
@@ -17,4 +18,5 @@ package object instances {
   object componentType extends ComponentTypeInstances
   object paymentFrequency extends PaymentFrequencyInstances
   object paymentProvider extends PaymentProviderInstances
+  object queryParamter extends QueryParameterInstances
 }

--- a/src/main/scala/com/gu/acquisition/instances/queryParameter.scala
+++ b/src/main/scala/com/gu/acquisition/instances/queryParameter.scala
@@ -1,0 +1,26 @@
+package com.gu.acquisition.instances
+
+import com.gu.fezziwig.CirceScroogeMacros._
+import io.circe.{Decoder, Encoder}
+import ophan.thrift.event.QueryParameter
+import play.api.libs.json._
+
+trait QueryParameterInstances {
+  // Ignore IntelliJ - these imports are used!
+  import cats.syntax.either._
+
+  implicit val queryParameterDecoder: Decoder[QueryParameter] = decodeThriftStruct[QueryParameter]
+
+  implicit val queryParameterEncoder: Encoder[QueryParameter] = encodeThriftStruct[QueryParameter]
+
+  implicit val queryParameterReads: Reads[QueryParameter] = {
+    import play.api.libs.functional.syntax._
+    ((__ \ "name").read[String] and (__ \ "value").read[String]) { (name, value) =>
+      QueryParameter(name, value)
+    }
+  }
+
+  implicit val queryParameterWrites: Writes[QueryParameter] = Writes { queryParameter =>
+    Json.obj("name" -> queryParameter.name, "value" -> queryParameter.value)
+  }
+}

--- a/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
+++ b/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
@@ -3,7 +3,7 @@ package com.gu.acquisition.model
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto._
 import ophan.thrift.componentEvent.ComponentType
-import ophan.thrift.event.{AbTest, AcquisitionSource}
+import ophan.thrift.event.{AbTest, AcquisitionSource, QueryParameter}
 import play.api.libs.json.{Reads, Writes, Json => PlayJson}
 
 /**
@@ -17,7 +17,8 @@ case class ReferrerAcquisitionData(
     componentType: Option[ComponentType],
     source: Option[AcquisitionSource],
     abTest: Option[AbTest], //Deprecated, please use abTests
-    abTests: Option[Set[AbTest]]
+    abTests: Option[Set[AbTest]],
+    queryParameters: Option[Set[QueryParameter]]
 )
 
 object ReferrerAcquisitionData {
@@ -25,6 +26,8 @@ object ReferrerAcquisitionData {
   import com.gu.acquisition.instances.abTest._
   import com.gu.acquisition.instances.acquisitionSource._
   import com.gu.acquisition.instances.componentType._
+  import com.gu.acquisition.instances.componentType._
+  import com.gu.acquisition.instances.queryParamter._
 
   implicit val referrerAcquisitionDataDecoder: Decoder[ReferrerAcquisitionData] = deriveDecoder[ReferrerAcquisitionData]
 

--- a/src/test/scala/com/gu/acquisition/model/ReferrerAcquisitionSpec.scala
+++ b/src/test/scala/com/gu/acquisition/model/ReferrerAcquisitionSpec.scala
@@ -3,7 +3,7 @@ package com.gu.acquisition.model
 import io.circe.{Json => CJson}
 import play.api.libs.json.{JsObject, Json => PJson}
 import ophan.thrift.componentEvent.ComponentType
-import ophan.thrift.event.{AbTest, AcquisitionSource}
+import ophan.thrift.event.{AbTest, AcquisitionSource, QueryParameter}
 import org.scalatest.{EitherValues, Matchers, WordSpecLike}
 
 class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValues {
@@ -16,7 +16,8 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
     componentType = Some(ComponentType.AcquisitionsEpic),
     source = Some(AcquisitionSource.GuardianWeb),
     abTest = Some(AbTest("test_name", "variant_name")),
-    abTests = Some(Set(AbTest("test_name", "variant_name"), AbTest("test_name2", "variant_name2")))
+    abTests = Some(Set(AbTest("test_name", "variant_name"), AbTest("test_name2", "variant_name2"))),
+    queryParameters = Some(Set(QueryParameter("param1", "val1"), QueryParameter("param2", "val2")))
   )
 
   val referrerAcquisitionCJson: CJson = CJson.obj(
@@ -38,6 +39,16 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
       CJson.obj(
         "name" -> CJson.fromString("test_name2"),
         "variant" -> CJson.fromString("variant_name2")
+      )
+    ),
+    "queryParameters" -> CJson.arr(
+      CJson.obj(
+        "name" -> CJson.fromString("param1"),
+        "value" -> CJson.fromString("val1")
+      ),
+      CJson.obj(
+        "name" -> CJson.fromString("param2"),
+        "value" -> CJson.fromString("val2")
       )
     )
   )
@@ -61,6 +72,16 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
       PJson.obj(
         "name" -> "test_name2",
         "variant" -> "variant_name2"
+      )
+    ),
+    "queryParameters" -> PJson.arr(
+      PJson.obj(
+        "name" -> "param1",
+        "value" -> "val1"
+      ),
+      PJson.obj(
+        "name" -> "param2",
+        "value" -> "val2"
       )
     )
   )


### PR DESCRIPTION
We want to store any query parameters associated with an acquisition in order to be able to track off platform properly. 

Follows on from https://github.com/guardian/ophan/pull/2687

@guardian/contributions 