### PR TITLE
Stop using `uid` in GA requests and use `cid` instead

### DIFF
--- a/src/main/scala/com/gu/acquisition/model/GAData.scala
+++ b/src/main/scala/com/gu/acquisition/model/GAData.scala
@@ -1,9 +1,17 @@
 package com.gu.acquisition.model
 
+/**
+ * Describes the information that Google Analytics needs to track correctly
+ * @param hostname - Used to distinguish the site that this conversion comes from this helps with GA views
+ * @param clientId - The GA client id used to identify unique devices, can be retrieved from the _ga cookie
+ * @param clientIpAddress - Allows GA to to compute all the geo / network dimensions.
+ * @param clientUserAgent - Allows GA to compute the browser, platform, and mobile capabilities dimensions.
+ */
 case class GAData(
-  hostname: String, // Used to distinguish the site that this conversion comes from this helps with GA views
-  clientIp: Option[String], // allows GA to to compute all the geo / network dimensions.
-  clientUserAgent: Option[String] // allows GA to compute the browser, platform, and mobile capabilities dimensions.
+  hostname: String,
+  clientId: String,
+  clientIpAddress: Option[String],
+  clientUserAgent: Option[String]
 )
 
 object GAData {

--- a/src/test/scala/com/gu/acquisition/app/AcquisitionSubmissionSimulation.scala
+++ b/src/test/scala/com/gu/acquisition/app/AcquisitionSubmissionSimulation.scala
@@ -19,7 +19,7 @@ object BasicMockDataGenerator extends MockDataGenerator {
   override def generateSubmission: AcquisitionSubmission =
     AcquisitionSubmission(
       OphanIds(Some("pageviewId"), Some("visitId"), Some("browserId")),
-      GAData("support.theguardian.com", None, None),
+      GAData("support.theguardian.com", "GA1.1.1633795050.1537436107", None, None),
       Acquisition(
         product = ophan.thrift.event.Product.Contribution,
         paymentFrequency = PaymentFrequency.OneOff,

--- a/src/test/scala/com/gu/acquisition/services/DefaultAcquisitionServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/DefaultAcquisitionServiceSpec.scala
@@ -15,7 +15,7 @@ class DefaultAcquisitionServiceSpec extends AsyncWordSpecLike with Matchers with
 
   val submission = AcquisitionSubmission(
     OphanIds(None, None, Some("None")),
-    GAData("support.code.dev-theguardian.com", None, None),
+    GAData("support.code.dev-theguardian.com", "GA1.1.1633795050.1537436107", None, None),
     Acquisition(
       product = ophan.thrift.event.Product.RecurringContribution,
       paymentFrequency = PaymentFrequency.Monthly,

--- a/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
@@ -28,7 +28,7 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
     componentTypeV2 = None,
     source = None
   )
-  val gaData = GAData("support.code.dev-theguardian.com", None, None)
+  val gaData = GAData("support.code.dev-theguardian.com", "GA1.1.1633795050.1537436107", None, None)
   val submission = AcquisitionSubmission(
     OphanIds(None, Some("123456789"), Some("987654321")),
     gaData,
@@ -43,21 +43,7 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
       payloadMapWithUid.get("ec") shouldEqual Some("AcquisitionConversion")
       payloadMapWithUid.get("ea") shouldEqual Some("Contribution")
       payloadMapWithUid.get("cu") shouldEqual Some("GBP")
-      // The payload should only ever have one of 'cid' and 'uid'
-      // If we have an Ophan browserId then this is passed into uid
-      // If not then we pass a random value in 'cid'
-      payloadMapWithUid.get("uid") shouldEqual Some("987654321")
-      payloadMapWithUid.get("cid") shouldEqual None
-
-      val payloadWithCid = service.buildPayload(AcquisitionSubmission(
-        OphanIds(None, None, None),
-        gaData,
-        acquisition
-      ), Some("123"))
-      val payloadMapWithCid = payloadAsMap(payloadWithCid)
-      payloadMapWithCid.get("cid") shouldEqual Some("123")
-      payloadMapWithCid.get("uid") shouldEqual None
-
+      payloadMapWithUid.get("cid") shouldEqual Some("GA1.1.1633795050.1537436107")
     }
 
     "build a correct ABTest payload" in {

--- a/src/test/scala/com/gu/acquisition/services/OphanServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/OphanServiceSpec.scala
@@ -13,7 +13,7 @@ class OphanServiceSpec extends WordSpecLike with Matchers {
 
   val submission: AcquisitionSubmission = AcquisitionSubmission(
     OphanIds(Some("pageviewId"), Some("visitId"), Some("browserId")),
-    GAData("support.theguardian.com", None, None),
+    GAData("support.theguardian.com", "GA1.1.1633795050.1537436107", None, None),
     Acquisition(
       product = ophan.thrift.event.Product.Contribution,
       paymentFrequency = PaymentFrequency.OneOff,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.4-SNAPSHOT"
+version in ThisBuild := "4.0.5-SNAPSHOT"


### PR DESCRIPTION
After [reading about `uid` and `cid`](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id) a bit more thoroughly I've realised that we shouldn't be using the Ophan browser id for `uid`, this should really be the users Identity id. 

That is a bit more tricky to do so for now I'm going to remove the user id tracking and use client id which calling code will need to pass in from the `_ga` cookie.