### PR TITLE
Remodel ga acquisition events

### DIFF
--- a/src/main/scala/com/gu/acquisition/model/ConversionCategory.scala
+++ b/src/main/scala/com/gu/acquisition/model/ConversionCategory.scala
@@ -2,18 +2,22 @@ package com.gu.acquisition.model
 
 private [acquisition] sealed trait ConversionCategory {
   val name: String
+  val description: String
 }
 
 private [acquisition] object ConversionCategory {
   case object PrintConversion extends ConversionCategory {
     override val name = "PrintConversion"
+    override val description = "PrintSubscription"
   }
 
   case object DigitalConversion extends ConversionCategory {
     override val name = "DigitalConversion"
+    override val description = "DigitalSubscription"
   }
 
   case object ContributionConversion extends ConversionCategory {
     override val name = "ContributionConversion"
+    override val description = "Contribution"
   }
 }

--- a/src/main/scala/com/gu/acquisition/model/ConversionCategory.scala
+++ b/src/main/scala/com/gu/acquisition/model/ConversionCategory.scala
@@ -1,0 +1,19 @@
+package com.gu.acquisition.model
+
+private [acquisition] sealed trait ConversionCategory {
+  val name: String
+}
+
+private [acquisition] object ConversionCategory {
+  case object PrintConversion extends ConversionCategory {
+    override val name = "PrintConversion"
+  }
+
+  case object DigitalConversion extends ConversionCategory {
+    override val name = "DigitalConversion"
+  }
+
+  case object ContributionConversion extends ConversionCategory {
+    override val name = "ContributionConversion"
+  }
+}

--- a/src/main/scala/com/gu/acquisition/services/GAService.scala
+++ b/src/main/scala/com/gu/acquisition/services/GAService.scala
@@ -46,7 +46,7 @@ private[services] class GAService(implicit client: OkHttpClient)
 
       // The GA conversion event
       "t" -> "event",
-      "ec" -> conversionCategory, //Event Category
+      "ec" -> conversionCategory.name, //Event Category
       "ea" -> productName, //Event Action
       "el" -> acquisition.paymentFrequency.name, //Event Label
       "ev" -> acquisition.amount.toInt.toString, //Event Value is an Integer
@@ -56,7 +56,7 @@ private[services] class GAService(implicit client: OkHttpClient)
       "tcc" -> acquisition.promoCode.getOrElse(""), // Transaction coupon.
       "pa" -> "purchase", //This is a purchase
       "pr1nm" -> productName, // Product Name
-      "pr1ca" -> conversionCategory, // Product category
+      "pr1ca" -> conversionCategory.description, // Product category
       "pr1pr" -> acquisition.amount.toString, // Product Price
       "pr1qt" -> "1", // Product Quantity
       "pr1cc" -> acquisition.promoCode.getOrElse(""), // Product coupon code.
@@ -73,14 +73,14 @@ private[services] class GAService(implicit client: OkHttpClient)
     acquisition.printOptions.map(_.product.name).getOrElse(acquisition.product.name)
 
   private[services] def getConversionCategory(acquisition: Acquisition) =
-    acquisition.printOptions.map(p => ConversionCategory.PrintConversion.name)
+    acquisition.printOptions.map(p => ConversionCategory.PrintConversion)
       .getOrElse(getDigitalConversionCategory(acquisition))
 
   private[services] def getDigitalConversionCategory(acquisition: Acquisition) =
     acquisition.product match {
       case _: Product.RecurringContribution.type |
-           _: Product.Contribution.type => ConversionCategory.ContributionConversion.name
-      case _ => ConversionCategory.DigitalConversion.name
+           _: Product.Contribution.type => ConversionCategory.ContributionConversion
+      case _ => ConversionCategory.DigitalConversion
     }
 
   private[services] def buildOptimizeTestsPayload(maybeTests: Option[AbTestInfo]) = {

--- a/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
@@ -1,7 +1,7 @@
 package com.gu.acquisition.services
 
 import cats.implicits._
-import com.gu.acquisition.model.{AcquisitionSubmission, GAData, OphanIds}
+import com.gu.acquisition.model._
 import com.typesafe.scalalogging.LazyLogging
 import okhttp3.OkHttpClient
 import ophan.thrift.event._
@@ -13,11 +13,11 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
 
   val service = new GAService
 
-  private val acquisition = Acquisition(
-    product = ophan.thrift.event.Product.Contribution,
-    paymentFrequency = PaymentFrequency.OneOff,
+  private val digiPack = Acquisition(
+    product = ophan.thrift.event.Product.DigitalSubscription,
+    paymentFrequency = PaymentFrequency.Monthly,
     currency = "GBP",
-    amount = 20d,
+    amount = 11.99,
     paymentProvider = Some(PaymentProvider.Stripe),
     campaignCode = Some(Set("FAKE_ACQUISITION_EVENT")),
     abTests = Some(AbTestInfo(Set(AbTest("test_name", "variant_name"), AbTest("second_test", "control")))),
@@ -28,11 +28,42 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
     componentTypeV2 = None,
     source = None
   )
+  private val weekly = Acquisition(
+    product = ophan.thrift.event.Product.PrintSubscription,
+    paymentFrequency = PaymentFrequency.Monthly,
+    currency = "GBP",
+    amount = 24.86,
+    paymentProvider = Some(PaymentProvider.Stripe),
+    campaignCode = Some(Set("FAKE_ACQUISITION_EVENT")),
+    abTests = Some(AbTestInfo(Set(AbTest("test_name", "variant_name"), AbTest("second_test", "control")))),
+    countryCode = Some("US"),
+    referrerPageViewId = None,
+    referrerUrl = None,
+    componentId = None,
+    componentTypeV2 = None,
+    source = None,
+    printOptions = Some(PrintOptions(PrintProduct.GuardianWeekly, "US"))
+  )
+  private val contribution = Acquisition(
+    product = ophan.thrift.event.Product.RecurringContribution,
+    paymentFrequency = PaymentFrequency.Monthly,
+    currency = "GBP",
+    amount = 5,
+    paymentProvider = Some(PaymentProvider.Stripe),
+    campaignCode = Some(Set("FAKE_ACQUISITION_EVENT")),
+    abTests = Some(AbTestInfo(Set(AbTest("test_name", "variant_name"), AbTest("second_test", "control")))),
+    countryCode = Some("US"),
+    referrerPageViewId = None,
+    referrerUrl = None,
+    componentId = None,
+    componentTypeV2 = None,
+    source = None,
+  )
   val gaData = GAData("support.code.dev-theguardian.com", "GA1.1.1633795050.1537436107", None, None)
   val submission = AcquisitionSubmission(
     OphanIds(None, Some("123456789"), Some("987654321")),
     gaData,
-    acquisition
+    digiPack
   )
 
 
@@ -58,8 +89,14 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
       tp.get._2 shouldEqual "0,1"
     }
 
+    "get the correct conversion category" in {
+      service.getConversionCategory(digiPack) shouldEqual ConversionCategory.DigitalConversion.name
+      service.getConversionCategory(weekly) shouldEqual ConversionCategory.PrintConversion.name
+      service.getConversionCategory(contribution) shouldEqual ConversionCategory.ContributionConversion.name
+    }
+
     //You can use this test to submit a request and the watch it in the Real-Time reports in the 'Support CODE' GA view.
-    "submit a request" ignore {
+    "submit a request" in {
       service.submit(submission).fold(
         serviceError => {
           logger.error(s"$serviceError")

--- a/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
@@ -60,25 +60,27 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
     source = None,
   )
   val gaData = GAData("support.code.dev-theguardian.com", "GA1.1.1633795050.1537436107", None, None)
+  val ophanIds = OphanIds(None, Some("123456789"), Some("987654321"))
   val submission = AcquisitionSubmission(
     OphanIds(None, Some("123456789"), Some("987654321")),
     gaData,
-    digiPack
+    weekly
   )
 
 
   "A GAService" should {
     "build a correct payload" in {
-      val payloadWithUid = service.buildPayload(submission)
-      val payloadMapWithUid = payloadAsMap(payloadWithUid)
-      payloadMapWithUid.get("ec") shouldEqual Some("AcquisitionConversion")
-      payloadMapWithUid.get("ea") shouldEqual Some("Contribution")
-      payloadMapWithUid.get("cu") shouldEqual Some("GBP")
-      payloadMapWithUid.get("cid") shouldEqual Some("GA1.1.1633795050.1537436107")
+      val payload = service.buildPayload(submission)
+      val payloadMap = payloadAsMap(payload)
+      payloadMap.get("ec") shouldEqual Some("PrintConversion")
+      payloadMap.get("ea") shouldEqual Some("GuardianWeekly")
+      payloadMap.get("cu") shouldEqual Some("GBP")
+      payloadMap.get("cid") shouldEqual Some("GA1.1.1633795050.1537436107")
+      payloadMap.get("pr1ca") shouldEqual Some("PrintSubscription")
     }
 
     "build a correct ABTest payload" in {
-      val tp = service.buildABTestPayload(submission.acquisition.abTests)
+      val tp = service.buildABTestPayload(digiPack.abTests)
       tp shouldEqual "test_name=variant_name,second_test=control"
     }
 
@@ -90,13 +92,13 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
     }
 
     "get the correct conversion category" in {
-      service.getConversionCategory(digiPack) shouldEqual ConversionCategory.DigitalConversion.name
-      service.getConversionCategory(weekly) shouldEqual ConversionCategory.PrintConversion.name
-      service.getConversionCategory(contribution) shouldEqual ConversionCategory.ContributionConversion.name
+      service.getConversionCategory(digiPack) shouldEqual ConversionCategory.DigitalConversion
+      service.getConversionCategory(weekly) shouldEqual ConversionCategory.PrintConversion
+      service.getConversionCategory(contribution) shouldEqual ConversionCategory.ContributionConversion
     }
 
     //You can use this test to submit a request and the watch it in the Real-Time reports in the 'Support CODE' GA view.
-    "submit a request" in {
+    "submit a request" ignore {
       service.submit(submission).fold(
         serviceError => {
           logger.error(s"$serviceError")


### PR DESCRIPTION
The current way that conversion events are modelled in GA doesn't give us enough information about the product that has been sold when the product is print. This PR remodels the event structure to make more comprehensive, it also adds some custom dimensions which were missing.

The new shape is:

`Category` -> the category of conversion, either `ContributionConversion`, `PrintConversion` or `DigitalConversion`
`Action` -> product name
`Label` -> billing period
`Value` -> amount of the contribution/cost of the product