### PR TITLE
Sanitise the GA client id input

### DIFF
--- a/src/main/scala/com/gu/acquisition/services/GAService.scala
+++ b/src/main/scala/com/gu/acquisition/services/GAService.scala
@@ -8,10 +8,13 @@ import com.typesafe.scalalogging.LazyLogging
 import okhttp3._
 import ophan.thrift.event.{AbTestInfo, Acquisition, Product}
 import GAService.clientIdPattern
+import cats.data.EitherT
+import com.gu.acquisition.model.errors.AnalyticsServiceError
+import com.gu.acquisition.model.errors.AnalyticsServiceError.BuildError
 
 import scala.util.matching.Regex
 
-private[services] object GAService{
+private[services] object GAService {
   val clientIdPattern: Regex = raw"GA\d\.\d\.(\d+)\..*".r
 }
 
@@ -21,66 +24,71 @@ private[services] class GAService(implicit client: OkHttpClient)
   private val gaPropertyId: String = "UA-51507017-5"
   private val endpoint: HttpUrl = HttpUrl.parse("https://www.google-analytics.com")
 
-  private[services] def buildBody(submission: AcquisitionSubmission) = {
-    RequestBody.create(null, buildPayload(submission))
+  private[services] def buildBody(submission: AcquisitionSubmission): Either[BuildError, RequestBody] = {
+    buildPayload(submission).map(payload => RequestBody.create(null, payload))
   }
 
-  private[services] def buildPayload(submission: AcquisitionSubmission, transactionId: Option[String] = None): String = {
+  private[services] def buildPayload(submission: AcquisitionSubmission, transactionId: Option[String] = None): Either[BuildError, String] = {
     import submission._
     val tid = transactionId.getOrElse(UUID.randomUUID().toString)
     val goExp = buildOptimizeTestsPayload(acquisition.abTests)
 
     // clientId cannot be empty or the call will fail
-    val clientId = sanitiseClientId(gaData.clientId)
-    val productName = getProductName(submission.acquisition)
-    val conversionCategory = getConversionCategory(submission.acquisition)
-    val body = Map(
-      "v" -> "1", //Version
-      "cid" -> clientId,
-      "tid" -> gaPropertyId,
-      "dh" -> gaData.hostname,
-      "uip" -> gaData.clientIpAddress.getOrElse(""), // IP Override
-      "ua" -> gaData.clientUserAgent.getOrElse(""), // User Agent Override
+    sanitiseClientId(gaData.clientId).map {
+      clientId =>
+        val productName = getProductName(submission.acquisition)
+        val conversionCategory = getConversionCategory(submission.acquisition)
+        val body = Map(
+          "v" -> "1", //Version
+          "cid" -> clientId,
+          "tid" -> gaPropertyId,
+          "dh" -> gaData.hostname,
+          "uip" -> gaData.clientIpAddress.getOrElse(""), // IP Override
+          "ua" -> gaData.clientUserAgent.getOrElse(""), // User Agent Override
 
-      // Custom Dimensions
-      "cd12" -> acquisition.campaignCode.map(_.mkString(",")), // Campaign code
-      "cd16" -> buildABTestPayload(acquisition.abTests), //'Experience' custom dimension
-      "cd17" -> acquisition.paymentProvider.getOrElse(""), // Payment method
+          // Custom Dimensions
+          "cd12" -> acquisition.campaignCode.map(_.mkString(",")), // Campaign code
+          "cd16" -> buildABTestPayload(acquisition.abTests), //'Experience' custom dimension
+          "cd17" -> acquisition.paymentProvider.getOrElse(""), // Payment method
 
-      // Google Optimize Experiment Id
-      "xid" -> goExp.map(_._1).getOrElse(""),
-      "xvar" -> goExp.map(_._2).getOrElse(""),
+          // Google Optimize Experiment Id
+          "xid" -> goExp.map(_._1).getOrElse(""),
+          "xvar" -> goExp.map(_._2).getOrElse(""),
 
-      // The GA conversion event
-      "t" -> "event",
-      "ec" -> conversionCategory.name, //Event Category
-      "ea" -> productName, //Event Action
-      "el" -> acquisition.paymentFrequency.name, //Event Label
-      "ev" -> acquisition.amount.toInt.toString, //Event Value is an Integer
+          // The GA conversion event
+          "t" -> "event",
+          "ec" -> conversionCategory.name, //Event Category
+          "ea" -> productName, //Event Action
+          "el" -> acquisition.paymentFrequency.name, //Event Label
+          "ev" -> acquisition.amount.toInt.toString, //Event Value is an Integer
 
-      // Enhanced Ecommerce tracking https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
-      "ti" -> tid,
-      "tcc" -> acquisition.promoCode.getOrElse(""), // Transaction coupon.
-      "pa" -> "purchase", //This is a purchase
-      "pr1nm" -> productName, // Product Name
-      "pr1ca" -> conversionCategory.description, // Product category
-      "pr1pr" -> acquisition.amount.toString, // Product Price
-      "pr1qt" -> "1", // Product Quantity
-      "pr1cc" -> acquisition.promoCode.getOrElse(""), // Product coupon code.
-      "cu" -> acquisition.currency.toString // Currency
-    )
+          // Enhanced Ecommerce tracking https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
+          "ti" -> tid,
+          "tcc" -> acquisition.promoCode.getOrElse(""), // Transaction coupon.
+          "pa" -> "purchase", //This is a purchase
+          "pr1nm" -> productName, // Product Name
+          "pr1ca" -> conversionCategory.description, // Product category
+          "pr1pr" -> acquisition.amount.toString, // Product Price
+          "pr1qt" -> "1", // Product Quantity
+          "pr1cc" -> acquisition.promoCode.getOrElse(""), // Product coupon code.
+          "cu" -> acquisition.currency.toString // Currency
+        )
 
-    body
-      .filter { case (key, value) => value != "" }
-      .map { case (key, value) => s"$key=$value" }
-      .mkString("&")
+        body
+          .filter { case (key, value) => value != "" }
+          .map { case (key, value) => s"$key=$value" }
+          .mkString("&")
+    }
   }
 
-  private[services] def sanitiseClientId(maybeId: String) = {
+  private[services] def sanitiseClientId(maybeId: String): Either[BuildError, String] = {
     maybeId match {
-      case clientIdPattern(id) => id // If we have a full _ga cookie string extract the client id
-      case "" => UUID.randomUUID().toString // If the provided value is blank we need to create one
-      case _ => maybeId // Otherwise assume that the caller has passed in the client id correctly
+      case clientIdPattern(id) => Right(id) // If we have a full _ga cookie string extract the client id
+      case "" => Left(BuildError("Client ID cannot be an empty string.\n" +
+        "To link server side with client side events you need to pass a valid clientId from the `_ga` cookie.\n" +
+        "Otherwise you can pass any non-empty string eg. `UUID.randomUUID().toString`\n" +
+        "More info here: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid"))
+      case _ => Right(maybeId) // Otherwise assume that the caller has passed in the client id correctly
     }
   }
 
@@ -119,18 +127,21 @@ private[services] class GAService(implicit client: OkHttpClient)
     }.getOrElse("")
 
 
-  override def buildRequest(submission: AcquisitionSubmission): RequestData = {
+  override def buildRequest(submission: AcquisitionSubmission): Either[BuildError, RequestData] = {
 
     val url = endpoint.newBuilder()
       .addPathSegment("collect")
       .build()
 
-    val request = new Request.Builder()
-      .url(url)
-      .addHeader("User-Agent", submission.gaData.clientUserAgent.getOrElse(""))
-      .post(buildBody(submission))
-      .build()
+    buildBody(submission).map {
+      requestBody =>
+        val request = new Request.Builder()
+          .url(url)
+          .addHeader("User-Agent", submission.gaData.clientUserAgent.getOrElse(""))
+          .post(requestBody)
+          .build()
 
-    RequestData(request, submission)
+        RequestData(request, submission)
+    }
   }
 }

--- a/src/main/scala/com/gu/acquisition/services/GAService.scala
+++ b/src/main/scala/com/gu/acquisition/services/GAService.scala
@@ -25,7 +25,11 @@ private[services] class GAService(implicit client: OkHttpClient)
   private val endpoint: HttpUrl = HttpUrl.parse("https://www.google-analytics.com")
 
   private[services] def buildBody(submission: AcquisitionSubmission): Either[BuildError, RequestBody] = {
-    buildPayload(submission).map(payload => RequestBody.create(null, payload))
+    buildPayload(submission).map{
+      payload =>
+        logger.info(s"GA Payload: $payload")
+        RequestBody.create(null, payload)
+    }
   }
 
   private[services] def buildPayload(submission: AcquisitionSubmission, transactionId: Option[String] = None): Either[BuildError, String] = {
@@ -47,7 +51,7 @@ private[services] class GAService(implicit client: OkHttpClient)
           "ua" -> gaData.clientUserAgent.getOrElse(""), // User Agent Override
 
           // Custom Dimensions
-          "cd12" -> acquisition.campaignCode.map(_.mkString(",")), // Campaign code
+          "cd12" -> acquisition.campaignCode.map(_.mkString(",")).getOrElse(""), // Campaign code
           "cd16" -> buildABTestPayload(acquisition.abTests), //'Experience' custom dimension
           "cd17" -> acquisition.paymentProvider.getOrElse(""), // Payment method
 

--- a/src/main/scala/com/gu/acquisition/services/GAService.scala
+++ b/src/main/scala/com/gu/acquisition/services/GAService.scala
@@ -3,14 +3,12 @@ package com.gu.acquisition.services
 import java.util.UUID
 
 import com.gu.acquisition.model._
+import com.gu.acquisition.model.errors.AnalyticsServiceError.BuildError
 import com.gu.acquisition.services.AnalyticsService.RequestData
+import com.gu.acquisition.services.GAService.clientIdPattern
 import com.typesafe.scalalogging.LazyLogging
 import okhttp3._
 import ophan.thrift.event.{AbTestInfo, Acquisition, Product}
-import GAService.clientIdPattern
-import cats.data.EitherT
-import com.gu.acquisition.model.errors.AnalyticsServiceError
-import com.gu.acquisition.model.errors.AnalyticsServiceError.BuildError
 
 import scala.util.matching.Regex
 
@@ -27,7 +25,6 @@ private[services] class GAService(implicit client: OkHttpClient)
   private[services] def buildBody(submission: AcquisitionSubmission): Either[BuildError, RequestBody] = {
     buildPayload(submission).map{
       payload =>
-        logger.info(s"GA Payload: $payload")
         RequestBody.create(null, payload)
     }
   }

--- a/src/main/scala/com/gu/acquisition/services/OphanService.scala
+++ b/src/main/scala/com/gu/acquisition/services/OphanService.scala
@@ -1,5 +1,6 @@
 package com.gu.acquisition.services
 
+import com.gu.acquisition.model.errors.AnalyticsServiceError.BuildError
 import com.gu.acquisition.model.{AcquisitionSubmission, SyntheticPageviewId}
 import com.gu.acquisition.services.AnalyticsService.RequestData
 import okhttp3._
@@ -18,7 +19,7 @@ private [acquisition] class OphanService(implicit client: OkHttpClient)
       .map { case (name, value) => name + "=" + value }
       .mkString(";")
 
-  override def buildRequest(submission: AcquisitionSubmission): RequestData = {
+  override def buildRequest(submission: AcquisitionSubmission): Either[BuildError, RequestData] = {
     import com.gu.acquisition.instances.acquisition._
     import io.circe.syntax._
     import submission._
@@ -34,7 +35,7 @@ private [acquisition] class OphanService(implicit client: OkHttpClient)
       .addHeader("Cookie", cookieValue(ophanIds.visitId, ophanIds.browserId))
       .build()
 
-    RequestData(request, submission)
+    Right(RequestData(request, submission))
   }
 
 

--- a/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
@@ -34,7 +34,7 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
     currency = "GBP",
     amount = 24.86,
     paymentProvider = Some(PaymentProvider.Stripe),
-    campaignCode = Some(Set("FAKE_ACQUISITION_EVENT")),
+    campaignCode = Some(Set("FAKE_ACQUISITION_EVENT1", "FAKE_ACQUISITION_EVENT2")),
     abTests = Some(AbTestInfo(Set(AbTest("test_name", "variant_name"), AbTest("second_test", "control")))),
     countryCode = Some("US"),
     referrerPageViewId = None,
@@ -75,15 +75,18 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
       service.sanitiseClientId("1234567") shouldEqual Right("1234567")
     }
     "build a correct payload" in {
-      service.buildPayload(submission).map{
-        payload =>
-          val payloadMap = payloadAsMap(payload)
-          payloadMap.get("ec") shouldEqual Some("PrintConversion")
-          payloadMap.get("ea") shouldEqual Some("GuardianWeekly")
-          payloadMap.get("cu") shouldEqual Some("GBP")
-          payloadMap.get("cid") shouldEqual Some("1633795050")
-          payloadMap.get("pr1ca") shouldEqual Some("PrintSubscription")
-      }.isRight shouldBe true
+      val maybePayload = service.buildPayload(submission)
+      maybePayload.isRight shouldBe true
+
+      logger.info(maybePayload.right.get)
+      val payloadMap = payloadAsMap(maybePayload.right.get)
+      payloadMap.get("ec") shouldEqual Some("PrintConversion")
+      payloadMap.get("ea") shouldEqual Some("GuardianWeekly")
+      payloadMap.get("cu") shouldEqual Some("GBP")
+      payloadMap.get("cid") shouldEqual Some("1633795050")
+      payloadMap.get("cd12") shouldEqual Some("FAKE_ACQUISITION_EVENT1,FAKE_ACQUISITION_EVENT2")
+      payloadMap.get("pr1ca") shouldEqual Some("PrintSubscription")
+
     }
 
     "build a correct ABTest payload" in {

--- a/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
@@ -69,6 +69,11 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
 
 
   "A GAService" should {
+    "get the correct Client ID" in {
+      service.sanitiseClientId("GA1.1.1633795050.1537436107") shouldEqual "1633795050"
+      service.sanitiseClientId("").length() should be > 0
+      service.sanitiseClientId("1234567") shouldEqual "1234567"
+    }
     "build a correct payload" in {
       val payload = service.buildPayload(submission)
       val payloadMap = payloadAsMap(payload)

--- a/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
@@ -70,18 +70,20 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
 
   "A GAService" should {
     "get the correct Client ID" in {
-      service.sanitiseClientId("GA1.1.1633795050.1537436107") shouldEqual "1633795050"
-      service.sanitiseClientId("").length() should be > 0
-      service.sanitiseClientId("1234567") shouldEqual "1234567"
+      service.sanitiseClientId("GA1.1.1633795050.1537436107") shouldEqual Right("1633795050")
+      service.sanitiseClientId("").isLeft shouldBe true
+      service.sanitiseClientId("1234567") shouldEqual Right("1234567")
     }
     "build a correct payload" in {
-      val payload = service.buildPayload(submission)
-      val payloadMap = payloadAsMap(payload)
-      payloadMap.get("ec") shouldEqual Some("PrintConversion")
-      payloadMap.get("ea") shouldEqual Some("GuardianWeekly")
-      payloadMap.get("cu") shouldEqual Some("GBP")
-      payloadMap.get("cid") shouldEqual Some("GA1.1.1633795050.1537436107")
-      payloadMap.get("pr1ca") shouldEqual Some("PrintSubscription")
+      service.buildPayload(submission).map{
+        payload =>
+          val payloadMap = payloadAsMap(payload)
+          payloadMap.get("ec") shouldEqual Some("PrintConversion")
+          payloadMap.get("ea") shouldEqual Some("GuardianWeekly")
+          payloadMap.get("cu") shouldEqual Some("GBP")
+          payloadMap.get("cid") shouldEqual Some("1633795050")
+          payloadMap.get("pr1ca") shouldEqual Some("PrintSubscription")
+      }.isRight shouldBe true
     }
 
     "build a correct ABTest payload" in {

--- a/src/test/scala/com/gu/acquisition/services/OphanServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/OphanServiceSpec.scala
@@ -37,13 +37,15 @@ class OphanServiceSpec extends WordSpecLike with Matchers {
 
       def checkRequest() = {
 
-        val request = service.buildRequest(submission).request
+        service.buildRequest(submission).map {
+          requestData =>
+            val request = requestData.request
+            request.method shouldEqual "GET"
+            request.header("Cookie") shouldEqual "vsid=visitId;bwid=browserId"
 
-        request.method shouldEqual "GET"
-        request.header("Cookie") shouldEqual "vsid=visitId;bwid=browserId"
-
-        request.url().url().toString shouldEqual
-          "https://ophan.theguardian.com/a.gif?viewId=pageviewId&acquisition={%22product%22:%22CONTRIBUTION%22,%22paymentFrequency%22:%22ONE_OFF%22,%22currency%22:%22GBP%22,%22amount%22:20.0,%22paymentProvider%22:%22STRIPE%22,%22campaignCode%22:[%22FAKE_ACQUISITION_EVENT%22],%22abTests%22:{%22tests%22:[{%22name%22:%22test_name%22,%22variant%22:%22variant_name%22}]},%22countryCode%22:%22US%22}"
+            request.url().url().toString shouldEqual
+              "https://ophan.theguardian.com/a.gif?viewId=pageviewId&acquisition={%22product%22:%22CONTRIBUTION%22,%22paymentFrequency%22:%22ONE_OFF%22,%22currency%22:%22GBP%22,%22amount%22:20.0,%22paymentProvider%22:%22STRIPE%22,%22campaignCode%22:[%22FAKE_ACQUISITION_EVENT%22],%22abTests%22:{%22tests%22:[{%22name%22:%22test_name%22,%22variant%22:%22variant_name%22}]},%22countryCode%22:%22US%22}"
+        }
       }
 
       // Check request is as expected


### PR DESCRIPTION
The [Measurement Protocol documentation](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid) doesn't make it very clear how to get hold of the correct client id in order to join up client side and server side events. 
You have to take it from the `_ga` cookie but not the entire contents as I previously thought but just a part of it. So in the cookie contents `GA1.1.1633795050.1537436107` what we need to send is `1633795050`. 

This PR tries to sanitise values passed in for the client id by extracting this value in the case that the entire cookie contents are sent as well as handling the case where a blank string is passed in.