### PR TITLE
Get the correct GA client Id format

### DIFF
--- a/src/main/scala/com/gu/acquisition/services/GAService.scala
+++ b/src/main/scala/com/gu/acquisition/services/GAService.scala
@@ -13,7 +13,7 @@ import ophan.thrift.event.{AbTestInfo, Acquisition, Product}
 import scala.util.matching.Regex
 
 private[services] object GAService {
-  val clientIdPattern: Regex = raw"GA\d\.\d\.(\d+)\..*".r
+  val clientIdPattern: Regex = raw"GA\d\.\d\.(\d+\.\d+)".r
 }
 
 private[services] class GAService(implicit client: OkHttpClient)

--- a/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
@@ -70,9 +70,9 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
 
   "A GAService" should {
     "get the correct Client ID" in {
-      service.sanitiseClientId("GA1.1.1633795050.1537436107") shouldEqual Right("1633795050")
+      service.sanitiseClientId("GA1.1.1633795050.1537436107") shouldEqual Right("1633795050.1537436107")
       service.sanitiseClientId("").isLeft shouldBe true
-      service.sanitiseClientId("1234567") shouldEqual Right("1234567")
+      service.sanitiseClientId("1633795050.1537436107") shouldEqual Right("1633795050.1537436107")
     }
     "build a correct payload" in {
       val maybePayload = service.buildPayload(submission)


### PR DESCRIPTION
I was given duff information regarding what GA expects to be passed in the clientId parameter, it should be the whole of the last part of the cookie contents eg. `1633795050.1537436107`.