### PR TITLE
Track annualised value in Google Analytics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,8 @@ val commonSettings: Seq[SettingsDefinition] = Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.github.mpilquist" %% "simulacrum" % "0.10.0",
     "com.gu" %% "fezziwig" % "0.8",
-    "com.gu" %% "ophan-event-model" % "0.0.6" excludeAll(ExclusionRule(organization = "com.typesafe.play")),
+    "com.gu" %% "ophan-event-model" % "0.0.6" excludeAll ExclusionRule(organization = "com.typesafe.play"),
+    "com.gu" %% "acquisitions-value-calculator-client" % "2.0.3",
     "com.squareup.okhttp3" % "okhttp" % "3.9.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
     "io.circe" %% "circe-core" % "0.9.1",
@@ -23,6 +24,9 @@ val commonSettings: Seq[SettingsDefinition] = Seq(
   bintrayRepository := "ophan",
   publishMavenStyle := true
 )
+
+resolvers += Resolver.sonatypeRepo("releases")
+
 
 // This project is compiled against multiple versions of `play-json` to aid compatibility.
 // The root build is published as `acquisition-event-producer` and uses play-json 2.4;

--- a/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
@@ -75,7 +75,7 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
       service.sanitiseClientId("1633795050.1537436107") shouldEqual Right("1633795050.1537436107")
     }
     "build a correct payload" in {
-      val maybePayload = service.buildPayload(submission)
+      val maybePayload = service.buildPayload(submission, 0D)
       maybePayload.isRight shouldBe true
 
       logger.info(maybePayload.right.get)

--- a/src/test/scala/com/gu/acquisition/services/OphanServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/OphanServiceSpec.scala
@@ -1,9 +1,11 @@
 package com.gu.acquisition.services
 
+import cats.implicits._
 import com.gu.acquisition.model.{AcquisitionSubmission, GAData, OphanIds}
 import okhttp3.OkHttpClient
 import ophan.thrift.event._
 import org.scalatest.{Matchers, WordSpecLike}
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class OphanServiceSpec extends WordSpecLike with Matchers {
 


### PR DESCRIPTION
# What does this PR do?
Annualised Value (AV) is the most important financial metric for us so it makes sense to track this in GA ecommerce reporting. This also allows us to set optimising AV as an objective in Google Optimize tests.

### Changes
* Track annualised value in the enhanced ecommerce Revenue metric
* Move the individual purchase price to a custom dimension so that we are still recording it

Related PR in acquisitions-value-calculator-client: https://github.com/guardian/acquisitions-value-calculator-client/pull/18