### PR TITLE
Allow ophan url override

### DIFF
--- a/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
+++ b/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
@@ -4,12 +4,12 @@ import cats.data.EitherT
 import com.gu.acquisition.model.AcquisitionSubmission
 import com.gu.acquisition.model.errors.AnalyticsServiceError
 import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
-import okhttp3.OkHttpClient
+import okhttp3.{HttpUrl, OkHttpClient}
 
 import scala.concurrent.ExecutionContext
 
-class DefaultAcquisitionService(implicit client: OkHttpClient) extends AcquisitionService {
-  private val ophanService = new OphanService()
+class DefaultAcquisitionService(ophanEndpoint: Option[HttpUrl] = None)(implicit client: OkHttpClient) extends AcquisitionService {
+  private val ophanService = new OphanService(ophanEndpoint)
   private val gAService = new GAService()
   override def submit[A: AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext) = {
     val ov = ophanService.submit(a).value

--- a/src/main/scala/com/gu/acquisition/services/OphanService.scala
+++ b/src/main/scala/com/gu/acquisition/services/OphanService.scala
@@ -13,10 +13,10 @@ import scala.concurrent.{ExecutionContext, Future}
   * Build an acquisition submission, and submit it to Ophan.
   * Uses OkHttp for executing the Http request.
   */
-private [acquisition] class OphanService(implicit client: OkHttpClient)
+private [acquisition] class OphanService(endpointOverride: Option[HttpUrl] = None)(implicit client: OkHttpClient)
   extends AnalyticsService {
 
-  private val endpoint: HttpUrl = HttpUrl.parse("https://ophan.theguardian.com")
+  private val endpoint: HttpUrl = endpointOverride getOrElse HttpUrl.parse("https://ophan.theguardian.com")
 
   private def cookieValue(visitId: Option[String], browserId: Option[String]): String =
     List(visitId.map(("vsid", _)), browserId.map(("bwid", _))).flatten


### PR DESCRIPTION
This is still needed by `payment-api` for test environment