### PR TITLE
Add fields to ReferrerAcquisitionData for GA

### DIFF
--- a/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
+++ b/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
@@ -18,7 +18,11 @@ case class ReferrerAcquisitionData(
     source: Option[AcquisitionSource],
     abTest: Option[AbTest], //Deprecated, please use abTests
     abTests: Option[Set[AbTest]],
-    queryParameters: Option[Set[QueryParameter]]
+    queryParameters: Option[Set[QueryParameter]],
+    hostname: Option[String],
+    gaClientId: Option[String],
+    userAgent: Option[String],
+    ipAddress: Option[String]
 )
 
 object ReferrerAcquisitionData {

--- a/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
+++ b/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
@@ -10,19 +10,19 @@ import play.api.libs.json.{Reads, Writes, Json => PlayJson}
   * Model for acquisition data passed by the referrer.
   */
 case class ReferrerAcquisitionData(
-    campaignCode: Option[String],
-    referrerPageviewId: Option[String],
-    referrerUrl: Option[String],
-    componentId: Option[String],
-    componentType: Option[ComponentType],
-    source: Option[AcquisitionSource],
-    abTest: Option[AbTest], //Deprecated, please use abTests
-    abTests: Option[Set[AbTest]],
-    queryParameters: Option[Set[QueryParameter]],
-    hostname: Option[String],
-    gaClientId: Option[String],
-    userAgent: Option[String],
-    ipAddress: Option[String]
+  campaignCode: Option[String],
+  referrerPageviewId: Option[String],
+  referrerUrl: Option[String],
+  componentId: Option[String],
+  componentType: Option[ComponentType],
+  source: Option[AcquisitionSource],
+  abTest: Option[AbTest], //Deprecated, please use abTests
+  abTests: Option[Set[AbTest]],
+  queryParameters: Option[Set[QueryParameter]],
+  hostname: Option[String],
+  gaClientId: Option[String],
+  userAgent: Option[String],
+  ipAddress: Option[String]
 )
 
 object ReferrerAcquisitionData {

--- a/src/test/scala/com/gu/acquisition/model/ReferrerAcquisitionSpec.scala
+++ b/src/test/scala/com/gu/acquisition/model/ReferrerAcquisitionSpec.scala
@@ -17,7 +17,11 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
     source = Some(AcquisitionSource.GuardianWeb),
     abTest = Some(AbTest("test_name", "variant_name")),
     abTests = Some(Set(AbTest("test_name", "variant_name"), AbTest("test_name2", "variant_name2"))),
-    queryParameters = Some(Set(QueryParameter("param1", "val1"), QueryParameter("param2", "val2")))
+    queryParameters = Some(Set(QueryParameter("param1", "val1"), QueryParameter("param2", "val2"))),
+    hostname = Some("hostname"),
+    gaClientId = Some("gaClientId"),
+    userAgent = Some("userAgent"),
+    ipAddress = Some("ipAddress")
   )
 
   val referrerAcquisitionCJson: CJson = CJson.obj(
@@ -50,7 +54,11 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
         "name" -> CJson.fromString("param2"),
         "value" -> CJson.fromString("val2")
       )
-    )
+    ),
+    "hostname" -> CJson.fromString("hostname"),
+    "gaClientId" -> CJson.fromString("gaClientId"),
+    "userAgent" -> CJson.fromString("userAgent"),
+    "ipAddress" -> CJson.fromString("ipAddress")
   )
 
   val referrerAcquisitionPJson: JsObject = PJson.obj(
@@ -83,7 +91,11 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
         "name" -> "param2",
         "value" -> "val2"
       )
-    )
+    ),
+    "hostname" -> "hostname",
+    "gaClientId" -> "gaClientId",
+    "userAgent" -> "userAgent",
+    "ipAddress" -> "ipAddress"
   )
 
   "Referrer acquisition data" should {


### PR DESCRIPTION
To allow support-frontend to pass through data for google analytics events to support-workers lambdas

Our GAData model - https://github.com/guardian/acquisition-event-producer/blob/master/src/main/scala/com/gu/acquisition/model/GAData.scala