### PR TITLE
Add kinesis events stream as a default service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,8 @@ val commonSettings: Seq[SettingsDefinition] = Seq(
     "org.scalatest" %% "scalatest" % "3.0.1" % "test",
     "org.scalactic" %% "scalactic" % "3.0.1",
     "org.typelevel" %% "cats-core" % "1.0.1",
+    "com.amazonaws" % "aws-java-sdk-kinesis" % "1.11.465",
+    "com.gu" %% "thrift-serializer" % "3.0.0",
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   ),
 

--- a/src/main/scala/com/gu/acquisition/model/errors/AnalyticsServiceError.scala
+++ b/src/main/scala/com/gu/acquisition/model/errors/AnalyticsServiceError.scala
@@ -21,5 +21,9 @@ object AnalyticsServiceError {
       s"HTTP request failed: ${failedResponse.code}"
     }
   }
+
+  case class KinesisError(e: Throwable) extends AnalyticsServiceError {
+    override def getMessage: String = s"Kinesis put error: $e"
+  }
 }
 

--- a/src/main/scala/com/gu/acquisition/services/AcquisitionService.scala
+++ b/src/main/scala/com/gu/acquisition/services/AcquisitionService.scala
@@ -14,6 +14,6 @@ trait AcquisitionService {
 
 object AcquisitionService {
 
-  def prod(implicit client: OkHttpClient): DefaultAcquisitionService =
-    new DefaultAcquisitionService()
+  def prod(config: DefaultAcquisitionServiceConfig)(implicit client: OkHttpClient): DefaultAcquisitionService =
+    new DefaultAcquisitionService(config)
 }

--- a/src/main/scala/com/gu/acquisition/services/AnalyticsService.scala
+++ b/src/main/scala/com/gu/acquisition/services/AnalyticsService.scala
@@ -1,65 +1,12 @@
 package com.gu.acquisition.services
 
-import java.io.IOException
-
 import cats.data.EitherT
 import com.gu.acquisition.model.AcquisitionSubmission
 import com.gu.acquisition.model.errors.AnalyticsServiceError
-import com.gu.acquisition.model.errors.AnalyticsServiceError.{BuildError, NetworkFailure, ResponseUnsuccessful}
-import com.gu.acquisition.services.AnalyticsService.RequestData
 import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
-import okhttp3._
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.control.NonFatal
+import scala.concurrent.{ExecutionContext, Future}
 
-private [acquisition] abstract class AnalyticsService(implicit client: OkHttpClient) {
-
-  protected def buildRequest(submission: AcquisitionSubmission)(implicit ec: ExecutionContext): EitherT[Future, BuildError, RequestData]
-
-  private def executeRequest(data: RequestData): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission] = {
-
-    val p = Promise[Either[AnalyticsServiceError, AcquisitionSubmission]]
-
-    client.newCall(data.request).enqueue(new Callback {
-
-      override def onFailure(call: Call, e: IOException): Unit =
-        p.success(Left(NetworkFailure(e)))
-
-      private def close(response: Response): Unit =
-        try {
-          response.close()
-        } catch {
-          case NonFatal(_) =>
-        }
-
-      override def onResponse(call: Call, response: Response): Unit =
-        try {
-          if (response.isSuccessful) p.success(Right(data.submission))
-          else p.success(Left(ResponseUnsuccessful(data.request, response)))
-        } finally {
-          close(response)
-        }
-    })
-
-    EitherT(p.future)
-  }
-
-  def submit[A : AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission] = {
-
-    import AcquisitionSubmissionBuilder.ops._
-    import cats.instances.future._
-
-    for {
-      submission <- EitherT.fromEither(a.asAcquisitionSubmission)
-      request <- buildRequest(submission)
-      result <- executeRequest(request)
-    } yield result
-  }
-
-}
-
-object AnalyticsService {
-
-  private[services] case class RequestData(request: Request, submission: AcquisitionSubmission)
+private [acquisition] trait AnalyticsService {
+  def submit[A : AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission]
 }

--- a/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
+++ b/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
@@ -1,6 +1,7 @@
 package com.gu.acquisition.services
 
 import cats.data.EitherT
+import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.gu.acquisition.model.AcquisitionSubmission
 import com.gu.acquisition.model.errors.AnalyticsServiceError
 import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
@@ -8,28 +9,37 @@ import okhttp3.{HttpUrl, OkHttpClient}
 
 import scala.concurrent.ExecutionContext
 
-class DefaultAcquisitionService(ophanEndpoint: Option[HttpUrl] = None)(implicit client: OkHttpClient) extends AcquisitionService {
-  private val ophanService = new OphanService(ophanEndpoint)
+case class DefaultAcquisitionServiceConfig(
+  credentialsProvider: AWSCredentialsProviderChain,
+  kinesisStreamName: String,
+  ophanEndpoint: Option[HttpUrl] = None
+)
+
+class DefaultAcquisitionService(config: DefaultAcquisitionServiceConfig)(implicit client: OkHttpClient) extends AcquisitionService {
+  private val ophanService = new OphanService(config.ophanEndpoint)
   private val gAService = new GAService()
+  private val kinesisService = new KinesisService(config.credentialsProvider, config.kinesisStreamName)
+
   override def submit[A: AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext) = {
     val ov = ophanService.submit(a).value
     val gv = gAService.submit(a).value
+    val kv = kinesisService.submit(a).value
     val result = for {
       o <- ov
       g <- gv
-    } yield mergeEithers(o, g)
+      k <- kv
+    } yield mergeEithers(List(o, g, k))
     EitherT(result)
   }
 
-  // Take 2 Eithers of type Either[AnalyticsServiceError, AcquisitionSubmission] and return Right(AcquisitionSubmission) if they both succeed
-  // or a Left(List[AnalyticsServiceError]) if one or both submissions fail.
-  def mergeEithers(e1: Either[AnalyticsServiceError, AcquisitionSubmission], e2: Either[AnalyticsServiceError, AcquisitionSubmission]): Either[List[AnalyticsServiceError], AcquisitionSubmission] = {
-    val errors = e1.swap.toSeq ++ e2.swap.toSeq
-    val submission = e1.toSeq ++ e2.toSeq
-    if (errors == Nil) {
-      Right(submission.head)
-    } else {
-      Left(errors.toList)
+  // Return the AcquisitionSubmission only if there are no errors, otherwise the full List[AnalyticsServiceError]
+  def mergeEithers(eithers: List[Either[AnalyticsServiceError, AcquisitionSubmission]]): Either[List[AnalyticsServiceError], AcquisitionSubmission] = {
+    val errors: List[AnalyticsServiceError] = eithers.flatMap(_.swap.toOption)
+    val submission: Option[AcquisitionSubmission] = eithers.collectFirst { case Right(s) => s }
+
+    (errors, submission) match {
+      case (Nil, Some(s)) => Right(s)
+      case _ => Left(errors)
     }
   }
 }

--- a/src/main/scala/com/gu/acquisition/services/GAService.scala
+++ b/src/main/scala/com/gu/acquisition/services/GAService.scala
@@ -6,7 +6,7 @@ import cats.data.EitherT
 import cats.implicits._
 import com.gu.acquisition.model._
 import com.gu.acquisition.model.errors.AnalyticsServiceError.BuildError
-import com.gu.acquisition.services.AnalyticsService.RequestData
+import com.gu.acquisition.services.HttpAnalyticsService.RequestData
 import com.gu.acquisition.services.GAService.clientIdPattern
 import com.gu.acquisitionsValueCalculatorClient.model.{AcquisitionModel, PrintOptionsModel}
 import com.gu.acquisitionsValueCalculatorClient.service.AnnualisedValueService
@@ -22,7 +22,7 @@ private[services] object GAService {
 }
 
 private[services] class GAService(implicit client: OkHttpClient)
-  extends AnalyticsService with LazyLogging {
+  extends HttpAnalyticsService with LazyLogging {
 
   private val gaPropertyId: String = "UA-51507017-5"
   private val endpoint: HttpUrl = HttpUrl.parse("https://www.google-analytics.com")

--- a/src/main/scala/com/gu/acquisition/services/HttpAnalyticsService.scala
+++ b/src/main/scala/com/gu/acquisition/services/HttpAnalyticsService.scala
@@ -1,0 +1,65 @@
+package com.gu.acquisition.services
+
+import java.io.IOException
+
+import cats.data.EitherT
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.AnalyticsServiceError
+import com.gu.acquisition.model.errors.AnalyticsServiceError.{BuildError, NetworkFailure, ResponseUnsuccessful}
+import com.gu.acquisition.services.HttpAnalyticsService.RequestData
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+import okhttp3._
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.control.NonFatal
+
+private [acquisition] abstract class HttpAnalyticsService(implicit client: OkHttpClient) extends AnalyticsService {
+
+  protected def buildRequest(submission: AcquisitionSubmission)(implicit ec: ExecutionContext): EitherT[Future, BuildError, RequestData]
+
+  private def executeRequest(data: RequestData): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission] = {
+
+    val p = Promise[Either[AnalyticsServiceError, AcquisitionSubmission]]
+
+    client.newCall(data.request).enqueue(new Callback {
+
+      override def onFailure(call: Call, e: IOException): Unit =
+        p.success(Left(NetworkFailure(e)))
+
+      private def close(response: Response): Unit =
+        try {
+          response.close()
+        } catch {
+          case NonFatal(_) =>
+        }
+
+      override def onResponse(call: Call, response: Response): Unit =
+        try {
+          if (response.isSuccessful) p.success(Right(data.submission))
+          else p.success(Left(ResponseUnsuccessful(data.request, response)))
+        } finally {
+          close(response)
+        }
+    })
+
+    EitherT(p.future)
+  }
+
+  def submit[A : AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission] = {
+
+    import AcquisitionSubmissionBuilder.ops._
+    import cats.instances.future._
+
+    for {
+      submission <- EitherT.fromEither(a.asAcquisitionSubmission)
+      request <- buildRequest(submission)
+      result <- executeRequest(request)
+    } yield result
+  }
+
+}
+
+object HttpAnalyticsService {
+
+  private[services] case class RequestData(request: Request, submission: AcquisitionSubmission)
+}

--- a/src/main/scala/com/gu/acquisition/services/KinesisService.scala
+++ b/src/main/scala/com/gu/acquisition/services/KinesisService.scala
@@ -1,0 +1,60 @@
+package com.gu.acquisition.services
+
+import java.nio.ByteBuffer
+
+import cats.data.EitherT
+import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.services.kinesis.AmazonKinesisAsyncClientBuilder
+import com.amazonaws.services.kinesis.model.{PutRecordRequest, PutRecordResult}
+import com.gu.acquisition.model.AcquisitionSubmission
+import com.gu.acquisition.model.errors.AnalyticsServiceError
+import com.gu.acquisition.model.errors.AnalyticsServiceError.KinesisError
+import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+import com.gu.thrift.serializer.ThriftSerializer
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.control.NonFatal
+
+private [acquisition] class KinesisService(credentialsProvider: AWSCredentialsProviderChain, streamName: String, region: String = "eu-west-1") extends AnalyticsService {
+
+  private val kinesisClient = {
+    val builder = AmazonKinesisAsyncClientBuilder.standard()
+    builder.withCredentials(credentialsProvider).withRegion(region).build
+  }
+
+  private def putAcquisition(acquisitionSubmission: AcquisitionSubmission): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission] = {
+    val promise = Promise[Either[AnalyticsServiceError, AcquisitionSubmission]]()
+
+    val request: PutRecordRequest = {
+      val buffer = ByteBuffer.wrap {
+        ThriftSerializer.serializeToBytes(acquisitionSubmission.acquisition, userCompressionType = None, thriftBufferInitialSize = None)
+      }
+
+      new PutRecordRequest()
+        .withStreamName(streamName)
+        .withData(buffer)
+    }
+
+    kinesisClient.putRecordAsync(request, new AsyncHandler[PutRecordRequest, PutRecordResult] {
+      override def onError(exception: Exception): Unit = exception match {
+        case NonFatal(e) => promise.failure(KinesisError(e))
+        case fatal => promise.failure(fatal)
+      }
+
+      override def onSuccess(request: PutRecordRequest, result: PutRecordResult): Unit = promise.success(Right(acquisitionSubmission))
+    })
+
+    EitherT(promise.future)
+  }
+
+  def submit[A : AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext): EitherT[Future, AnalyticsServiceError, AcquisitionSubmission] = {
+    import AcquisitionSubmissionBuilder.ops._
+    import cats.instances.future._
+
+    for {
+      submission <- EitherT.fromEither(a.asAcquisitionSubmission)
+      result <- putAcquisition(submission)
+    } yield result
+  }
+}

--- a/src/main/scala/com/gu/acquisition/services/KinesisService.scala
+++ b/src/main/scala/com/gu/acquisition/services/KinesisService.scala
@@ -33,6 +33,7 @@ private [acquisition] class KinesisService(credentialsProvider: AWSCredentialsPr
 
       new PutRecordRequest()
         .withStreamName(streamName)
+        .withPartitionKey(acquisitionSubmission.acquisition.identityId.getOrElse(acquisitionSubmission.acquisition.amount.toString))
         .withData(buffer)
     }
 

--- a/src/main/scala/com/gu/acquisition/services/OphanService.scala
+++ b/src/main/scala/com/gu/acquisition/services/OphanService.scala
@@ -4,7 +4,7 @@ import cats.data.EitherT
 import cats.implicits._
 import com.gu.acquisition.model.errors.AnalyticsServiceError.BuildError
 import com.gu.acquisition.model.{AcquisitionSubmission, SyntheticPageviewId}
-import com.gu.acquisition.services.AnalyticsService.RequestData
+import com.gu.acquisition.services.HttpAnalyticsService.RequestData
 import okhttp3._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -14,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * Uses OkHttp for executing the Http request.
   */
 private [acquisition] class OphanService(endpointOverride: Option[HttpUrl] = None)(implicit client: OkHttpClient)
-  extends AnalyticsService {
+  extends HttpAnalyticsService {
 
   private val endpoint: HttpUrl = endpointOverride getOrElse HttpUrl.parse("https://ophan.theguardian.com")
 


### PR DESCRIPTION
The stream will initially be used to write acquisitions to s3, where they will be used for the 'ticker' on the banner/epic during campaigns.

I've renamed `AnalyticsService` to `HttpAnalyticsService` but not changed the logic, and added a new more general `AnalyticsService`.
This is because `KinesisService` does not use the http client.