### PR TITLE
Make credentials provider optional

### DIFF
--- a/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
+++ b/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
@@ -9,16 +9,20 @@ import okhttp3.{HttpUrl, OkHttpClient}
 
 import scala.concurrent.ExecutionContext
 
-case class DefaultAcquisitionServiceConfig(
-  credentialsProvider: Option[AWSCredentialsProviderChain],
-  kinesisStreamName: String,
-  ophanEndpoint: Option[HttpUrl] = None
-)
+sealed trait DefaultAcquisitionServiceConfig {
+  val kinesisStreamName: String
+  val ophanEndpoint: Option[HttpUrl]
+}
+
+//Credentials provider is only required by the kinesis client when running in ec2 or locally
+case class Ec2OrLocalConfig(credentialsProvider: AWSCredentialsProviderChain, kinesisStreamName: String, ophanEndpoint: Option[HttpUrl] = None) extends DefaultAcquisitionServiceConfig
+
+case class LambdaConfig(kinesisStreamName: String, ophanEndpoint: Option[HttpUrl] = None) extends DefaultAcquisitionServiceConfig
 
 class DefaultAcquisitionService(config: DefaultAcquisitionServiceConfig)(implicit client: OkHttpClient) extends AcquisitionService {
   private val ophanService = new OphanService(config.ophanEndpoint)
   private val gAService = new GAService()
-  private val kinesisService = new KinesisService(config.credentialsProvider, config.kinesisStreamName)
+  private val kinesisService = new KinesisService(config)
 
   override def submit[A: AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext) = {
     val ov = ophanService.submit(a).value

--- a/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
+++ b/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
@@ -10,7 +10,7 @@ import okhttp3.{HttpUrl, OkHttpClient}
 import scala.concurrent.ExecutionContext
 
 case class DefaultAcquisitionServiceConfig(
-  credentialsProvider: AWSCredentialsProviderChain,
+  credentialsProvider: Option[AWSCredentialsProviderChain],
   kinesisStreamName: String,
   ophanEndpoint: Option[HttpUrl] = None
 )

--- a/src/test/scala/com/gu/acquisition/services/DefaultAcquisitionServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/DefaultAcquisitionServiceSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.{AsyncWordSpecLike, Matchers}
 class DefaultAcquisitionServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
   implicit val client: OkHttpClient = new OkHttpClient()
 
-  private val service = AcquisitionService.prod(DefaultAcquisitionServiceConfig(
+  private val service = AcquisitionService.prod(Ec2OrLocalConfig(
     credentialsProvider = new AWSCredentialsProviderChain(new EnvironmentVariableCredentialsProvider()),
     kinesisStreamName = "stream"
   ))


### PR DESCRIPTION
This worked locally and on an ec2, but a lambda should not give a credentials provider - it already implicitly has the permission.