### PR TITLE
Remove deprecated abTest field

### DIFF
--- a/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
+++ b/src/main/scala/com/gu/acquisition/model/ReferrerAcquisitionData.scala
@@ -16,7 +16,6 @@ case class ReferrerAcquisitionData(
   componentId: Option[String],
   componentType: Option[ComponentType],
   source: Option[AcquisitionSource],
-  abTest: Option[AbTest], //Deprecated, please use abTests
   abTests: Option[Set[AbTest]],
   queryParameters: Option[Set[QueryParameter]],
   hostname: Option[String],

--- a/src/test/scala/com/gu/acquisition/model/ReferrerAcquisitionSpec.scala
+++ b/src/test/scala/com/gu/acquisition/model/ReferrerAcquisitionSpec.scala
@@ -15,7 +15,6 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
     componentId = Some("component_id"),
     componentType = Some(ComponentType.AcquisitionsEpic),
     source = Some(AcquisitionSource.GuardianWeb),
-    abTest = Some(AbTest("test_name", "variant_name")),
     abTests = Some(Set(AbTest("test_name", "variant_name"), AbTest("test_name2", "variant_name2"))),
     queryParameters = Some(Set(QueryParameter("param1", "val1"), QueryParameter("param2", "val2"))),
     hostname = Some("hostname"),
@@ -31,10 +30,6 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
     "componentId" -> CJson.fromString("component_id"),
     "componentType" -> CJson.fromString("ACQUISITIONS_EPIC"),
     "source" -> CJson.fromString("GUARDIAN_WEB"),
-    "abTest" -> CJson.obj(
-      "name" -> CJson.fromString("test_name"),
-      "variant" -> CJson.fromString("variant_name")
-    ),
     "abTests" -> CJson.arr(
       CJson.obj(
         "name" -> CJson.fromString("test_name"),
@@ -68,10 +63,6 @@ class ReferrerAcquisitionSpec extends WordSpecLike with Matchers with EitherValu
     "componentId" -> "component_id",
     "componentType" -> "ACQUISITIONS_EPIC",
     "source" -> "GUARDIAN_WEB",
-    "abTest" -> PJson.obj(
-      "name" -> "test_name",
-      "variant" -> "variant_name"
-    ),
     "abTests" -> PJson.arr(
       PJson.obj(
         "name" -> "test_name",


### PR DESCRIPTION
This field shouldn't be used. So I'm removing it here and then will bump versions in `membership-frontend`, `subscriptions-frontend`, `support-workers` and `payment-api`