### PR TITLE
Make kinesis service optional

### DIFF
--- a/src/main/scala/com/gu/acquisition/services/AcquisitionService.scala
+++ b/src/main/scala/com/gu/acquisition/services/AcquisitionService.scala
@@ -14,10 +14,10 @@ trait AcquisitionService {
 
 object AcquisitionService {
 
-  def allServices(config: DefaultAcquisitionServiceConfig)(implicit client: OkHttpClient) = new DefaultAcquisitionService(List(
-    new OphanService(config.ophanEndpoint),
+  def allServices(kinesisConfig: KinesisServiceConfig, ophanEndpoint: Option[HttpUrl] = None)(implicit client: OkHttpClient) = new DefaultAcquisitionService(List(
+    new OphanService(ophanEndpoint),
     new GAService(),
-    new KinesisService(config)
+    new KinesisService(kinesisConfig)
   ))
 
   def noKinesis(ophanEndpoint: Option[HttpUrl])(implicit client: OkHttpClient) = new DefaultAcquisitionService(List(

--- a/src/main/scala/com/gu/acquisition/services/AcquisitionService.scala
+++ b/src/main/scala/com/gu/acquisition/services/AcquisitionService.scala
@@ -4,7 +4,7 @@ import cats.data.EitherT
 import com.gu.acquisition.model.AcquisitionSubmission
 import com.gu.acquisition.model.errors.AnalyticsServiceError
 import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
-import okhttp3.OkHttpClient
+import okhttp3.{HttpUrl, OkHttpClient}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -14,6 +14,14 @@ trait AcquisitionService {
 
 object AcquisitionService {
 
-  def prod(config: DefaultAcquisitionServiceConfig)(implicit client: OkHttpClient): DefaultAcquisitionService =
-    new DefaultAcquisitionService(config)
+  def allServices(config: DefaultAcquisitionServiceConfig)(implicit client: OkHttpClient) = new DefaultAcquisitionService(List(
+    new OphanService(config.ophanEndpoint),
+    new GAService(),
+    new KinesisService(config)
+  ))
+
+  def noKinesis(ophanEndpoint: Option[HttpUrl])(implicit client: OkHttpClient) = new DefaultAcquisitionService(List(
+    new OphanService(ophanEndpoint),
+    new GAService()
+  ))
 }

--- a/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
+++ b/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
@@ -7,7 +7,7 @@ import com.gu.acquisition.model.errors.AnalyticsServiceError
 import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
 import okhttp3.{HttpUrl, OkHttpClient}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 sealed trait DefaultAcquisitionServiceConfig {
   val kinesisStreamName: String
@@ -19,21 +19,13 @@ case class Ec2OrLocalConfig(credentialsProvider: AWSCredentialsProviderChain, ki
 
 case class LambdaConfig(kinesisStreamName: String, ophanEndpoint: Option[HttpUrl] = None) extends DefaultAcquisitionServiceConfig
 
-class DefaultAcquisitionService(config: DefaultAcquisitionServiceConfig)(implicit client: OkHttpClient) extends AcquisitionService {
-  private val ophanService = new OphanService(config.ophanEndpoint)
-  private val gAService = new GAService()
-  private val kinesisService = new KinesisService(config)
+class DefaultAcquisitionService(services: List[AnalyticsService])(implicit client: OkHttpClient) extends AcquisitionService {
 
   override def submit[A: AcquisitionSubmissionBuilder](a: A)(implicit ec: ExecutionContext) = {
-    val ov = ophanService.submit(a).value
-    val gv = gAService.submit(a).value
-    val kv = kinesisService.submit(a).value
-    val result = for {
-      o <- ov
-      g <- gv
-      k <- kv
-    } yield mergeEithers(List(o, g, k))
-    EitherT(result)
+    EitherT {
+      val submitOps = services.map(_.submit(a).value)
+      Future.sequence(submitOps).map(mergeEithers)
+    }
   }
 
   // Return the AcquisitionSubmission only if there are no errors, otherwise the full List[AnalyticsServiceError]

--- a/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
+++ b/src/main/scala/com/gu/acquisition/services/DefaultAcquisitionService.scala
@@ -1,23 +1,12 @@
 package com.gu.acquisition.services
 
 import cats.data.EitherT
-import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.gu.acquisition.model.AcquisitionSubmission
 import com.gu.acquisition.model.errors.AnalyticsServiceError
 import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
-import okhttp3.{HttpUrl, OkHttpClient}
+import okhttp3.OkHttpClient
 
 import scala.concurrent.{ExecutionContext, Future}
-
-sealed trait DefaultAcquisitionServiceConfig {
-  val kinesisStreamName: String
-  val ophanEndpoint: Option[HttpUrl]
-}
-
-//Credentials provider is only required by the kinesis client when running in ec2 or locally
-case class Ec2OrLocalConfig(credentialsProvider: AWSCredentialsProviderChain, kinesisStreamName: String, ophanEndpoint: Option[HttpUrl] = None) extends DefaultAcquisitionServiceConfig
-
-case class LambdaConfig(kinesisStreamName: String, ophanEndpoint: Option[HttpUrl] = None) extends DefaultAcquisitionServiceConfig
 
 class DefaultAcquisitionService(services: List[AnalyticsService])(implicit client: OkHttpClient) extends AcquisitionService {
 

--- a/src/test/scala/com/gu/acquisition/services/DefaultAcquisitionServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/DefaultAcquisitionServiceSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.{AsyncWordSpecLike, Matchers}
 class DefaultAcquisitionServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
   implicit val client: OkHttpClient = new OkHttpClient()
 
-  private val service = AcquisitionService.prod(Ec2OrLocalConfig(
+  private val service = AcquisitionService.allServices(Ec2OrLocalConfig(
     credentialsProvider = new AWSCredentialsProviderChain(new EnvironmentVariableCredentialsProvider()),
     kinesisStreamName = "stream"
   ))


### PR DESCRIPTION
Allow apps to create a `DefaultAcquisitionService` but without sending events to the kinesis stream.

We're unlikely to want subscription-frontend to send events to this stream, and we may also want to disable the stream elsewhere for cost savings (e.g. in CODE).

I've replaced `DefaultAcquisitionServiceConfig` with `KinesisServiceConfig`