### PR TITLE
Fire the successfulSubscriptionSignup custom metric for subs acquisitions

### DIFF
--- a/src/main/scala/com/gu/acquisition/services/GAService.scala
+++ b/src/main/scala/com/gu/acquisition/services/GAService.scala
@@ -56,6 +56,12 @@ private[services] class GAService(implicit client: OkHttpClient)
     EitherT(AnnualisedValueService.getAsyncAV(acquisitionModel, "ophan"))
   }
 
+  private def getSuccessfulSubscriptionSignUpMetric(conversionCategory: ConversionCategory) =
+    conversionCategory match {
+      case  _: ConversionCategory.ContributionConversion.type => ""
+      case _ => "1"
+  }
+
   private[services] def buildPayload(submission: AcquisitionSubmission, annualisedValue: Double, transactionId: Option[String] = None): Either[BuildError, String] = {
     import submission._
     val tid = transactionId.getOrElse(UUID.randomUUID().toString)
@@ -78,6 +84,9 @@ private[services] class GAService(implicit client: OkHttpClient)
           "cd12" -> acquisition.campaignCode.map(_.mkString(",")).getOrElse(""), // Campaign code
           "cd16" -> buildABTestPayload(acquisition.abTests), //'Experience' custom dimension
           "cd17" -> acquisition.paymentProvider.getOrElse(""), // Payment method
+
+          // Custom metrics
+          "cm10" -> getSuccessfulSubscriptionSignUpMetric(conversionCategory),
 
           // Google Optimize Experiment Id
           "xid" -> goExp.map(_._1).getOrElse(""),

--- a/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
+++ b/src/test/scala/com/gu/acquisition/services/GAServiceSpec.scala
@@ -89,6 +89,34 @@ class GAServiceSpec extends AsyncWordSpecLike with Matchers with LazyLogging {
 
     }
 
+    "Include the correct successfulSubscriptionSignUp value" in {
+      val contributionPayload = payloadAsMap(
+        service
+          .buildPayload(AcquisitionSubmission(ophanIds, gaData, contribution), 25)
+          .right.get
+      )
+
+      contributionPayload.get("cm10") shouldEqual None
+
+      val digiPackPayload = payloadAsMap(
+        service
+          .buildPayload(AcquisitionSubmission(ophanIds, gaData, digiPack), 25)
+          .right.get
+      )
+
+      digiPackPayload.get("cm10") shouldEqual Some("1")
+
+      val weeklyPayload = payloadAsMap(
+        service
+          .buildPayload(AcquisitionSubmission(ophanIds, gaData, weekly), 25)
+          .right.get
+      )
+
+      weeklyPayload.get("cm10") shouldEqual Some("1")
+
+
+    }
+
     "build a correct ABTest payload" in {
       val tp = service.buildABTestPayload(digiPack.abTests)
       tp shouldEqual "test_name=variant_name,second_test=control"


### PR DESCRIPTION
Apparently a lot of reports used by BRR use the `successfulSubscriptionSignup` GA custom metric so we should set this to 1 for any conversions other than contributions.