### PR TITLE
ophan-event-model 0.0.9 => 0.0.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val commonSettings: Seq[SettingsDefinition] = Seq(
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "com.github.mpilquist" %% "simulacrum" % "0.10.0",
     "com.gu" %% "fezziwig" % "0.8",
-    "com.gu" %% "ophan-event-model" % "0.0.9" excludeAll ExclusionRule(organization = "com.typesafe.play"),
+    "com.gu" %% "ophan-event-model" % "0.0.10" excludeAll ExclusionRule(organization = "com.typesafe.play"),
     "com.gu" %% "acquisitions-value-calculator-client" % "2.0.4",
     "com.squareup.okhttp3" % "okhttp" % "3.9.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",


### PR DESCRIPTION
From changes in https://github.com/guardian/ophan/pull/3229 (new componentType thrift enums)