### PR TITLE
Send the gift subscription custom dimension to GA

### DIFF
--- a/src/main/scala/com/gu/acquisition/services/GAService.scala
+++ b/src/main/scala/com/gu/acquisition/services/GAService.scala
@@ -86,6 +86,7 @@ private[services] class GAService(implicit client: OkHttpClient)
           "cd17" -> acquisition.paymentProvider.getOrElse(""), // Payment method
           "cd19" -> acquisition.promoCode.getOrElse(""), // Promo code
           "cd25" -> acquisition.labels.exists(_.contains("REUSED_EXISTING_PAYMENT_METHOD")), // usedExistingPaymentMethod
+          "cd26" -> acquisition.labels.exists(_.contains("gift-subscription")), // gift subscription
 
           // Custom metrics
           "cm10" -> getSuccessfulSubscriptionSignUpMetric(conversionCategory),


### PR DESCRIPTION
Now we have gifting for Guardian Weekly we want to record gift subscriptions in GA (they are already recorded in the data lake via labels)

[**Trello Card**](https://trello.com/c/Q33ZsM7n/2390-analytics)