### PR TITLE
bump apache libthrift (via guardian thrift)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val commonSettings: Seq[SettingsDefinition] = Seq(
     "org.scalactic" %% "scalactic" % "3.0.1",
     "org.typelevel" %% "cats-core" % "1.0.1",
     "com.amazonaws" % "aws-java-sdk-kinesis" % "1.11.465",
-    "com.gu" %% "thrift-serializer" % "4.0.3-SNAPSHOT",
+    "com.gu" %% "thrift-serializer" % "4.0.3",
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   ),
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val commonSettings: Seq[SettingsDefinition] = Seq(
     "org.scalactic" %% "scalactic" % "3.0.1",
     "org.typelevel" %% "cats-core" % "1.0.1",
     "com.amazonaws" % "aws-java-sdk-kinesis" % "1.11.465",
-    "com.gu" %% "thrift-serializer" % "4.0.2",
+    "com.gu" %% "thrift-serializer" % "4.0.3-SNAPSHOT",
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   ),
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.9

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.23"
+version in ThisBuild := "4.0.24"


### PR DESCRIPTION
This bumps the libthrift via https://github.com/guardian/thrift-serializer
due to https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-474610

Also updated sbt while I am in.